### PR TITLE
Use Tingwu client for ASR transcription

### DIFF
--- a/services/audio/asr_adapter.py
+++ b/services/audio/asr_adapter.py
@@ -4,12 +4,8 @@ import logging
 import os
 from typing import List, Optional
 
-from dashscope.multimodal.tingwu.tingwu_realtime import (
-    TingWuRealtime,
-    TingWuRealtimeCallback,
-)
-
 from packages.common.config import settings
+from services.audio import tingwu_client
 
 
 LOGGER = logging.getLogger(__name__)
@@ -42,69 +38,17 @@ class StubASR:
         return []
 
 
-class SDKTingWuASR:
-    """DashScope TingWu implementation used for realtime transcription."""
+class TingwuClientASR:
+    """Adapter wrapping the local Tingwu client implementation."""
 
-    def __init__(self, app_settings):
-        self.model = app_settings.TINGWU_MODEL or "paraformer-realtime-v2"
-        self.api_key = app_settings.DASHSCOPE_API_KEY
-        if not self.api_key:
-            raise AsrError("DASHSCOPE_API_KEY is required for TingWu SDK")
+    def __init__(self, _app_settings=settings):  # pragma: no cover - simple init
+        self._settings = _app_settings
 
-        self.app_id = app_settings.TINGWU_APP_ID
-        if not self.app_id:
-            raise AsrError("TINGWU_APP_ID is required for TingWu SDK")
-
-        self.base_address = getattr(app_settings, "TINGWU_BASE_ADDRESS", None)
-        self.audio_format = app_settings.TINGWU_FORMAT or "pcm"
-        self.sample_rate = int(app_settings.TINGWU_SR or 16000)
-        self.lang = app_settings.TINGWU_LANG or "cn"
-
-    class _Cb(TingWuRealtimeCallback):
-        def __init__(self):
-            self._inc = 0
-            self.segments: List[dict] = []
-
-        def on_recognize_result(self, result):  # type: ignore[override]
-            transcription = (
-                (result or {})
-                .get("payload", {})
-                .get("output", {})
-                .get("transcription", {})
-            )
-            if transcription.get("sentenceEnd") is True:
-                begin = transcription.get("beginTime") or 0
-                end = transcription.get("endTime") or 0
-                text = transcription.get("text") or ""
-                self._inc += 1
-                self.segments.append(
-                    {
-                        "utt_id": f"tw_{self._inc}",
-                        "text": text,
-                        "speaker": "patient",
-                        "ts": [begin / 1000.0, end / 1000.0],
-                        "conf": 0.95,
-                    }
-                )
-
-        def on_error(self, error):  # type: ignore[override]
-            LOGGER.debug("TingWu realtime error: %s", error)
-
-        def on_close(self):  # type: ignore[override]
-            LOGGER.debug("TingWu realtime closed")
-
-        def on_speech_listen(self, result):  # type: ignore[override]
-            LOGGER.debug("TingWu speech listen: %s", result)
-
-        def on_stopped(self, result):  # type: ignore[override]
-            LOGGER.debug("TingWu realtime stopped: %s", result)
-
-    def _read_bytes(self, path: str) -> bytes:
-        local_path = path.replace("file://", "") if path.startswith("file://") else path
+    def _resolve_path(self, path: str) -> str:
+        local_path = path.replace("file://", "", 1) if path.startswith("file://") else path
         if not os.path.exists(local_path):
             raise AsrError(f"audio file not found: {local_path}")
-        with open(local_path, "rb") as handle:
-            return handle.read()
+        return local_path
 
     def transcribe(
         self,
@@ -121,46 +65,47 @@ class SDKTingWuASR:
                     "conf": 0.95,
                 }
             ]
+
         if not audio_ref:
             raise AsrError("audio_ref required")
 
-        audio_bytes = self._read_bytes(audio_ref)
-        callback = self._Cb()
-        try:
-            tingwu = TingWuRealtime(
-                model=self.model,
-                audio_format=self.audio_format,
-                sample_rate=self.sample_rate,
-                app_id=self.app_id,
-                base_address=self.base_address,
-                api_key=self.api_key,
-                callback=callback,
-                max_end_silence=3000,
-            )
-            tingwu.start()
-            tingwu.send_audio_data(audio_bytes)
-            tingwu.stop()
-        except Exception as exc:  # pragma: no cover - network/SDK errors
-            raise AsrError(f"TingWu SDK transcription failed: {exc}") from exc
+        local_path = self._resolve_path(audio_ref)
 
-        return callback.segments
+        try:
+            transcript = tingwu_client.transcribe(local_path)
+        except EnvironmentError as exc:  # pragma: no cover - configuration guard
+            raise AsrError(f"Tingwu client misconfigured: {exc}") from exc
+        except Exception as exc:  # pragma: no cover - network/SDK errors
+            raise AsrError(f"Tingwu client transcription failed: {exc}") from exc
+
+        transcript = transcript.strip()
+        if not transcript:
+            return []
+
+        return [
+            {
+                "utt_id": "tw_1",
+                "text": transcript,
+                "speaker": "patient",
+                "ts": [0, 0],
+                "conf": 0.95,
+            }
+        ]
 
 
 DEFAULT_ASR = StubASR()
-_SDK_TINGWU_ASR: Optional[SDKTingWuASR] = None
+_TINGWU_CLIENT_ASR: Optional[TingwuClientASR] = None
 
 
-def _provider() -> StubASR | SDKTingWuASR:
-    global _SDK_TINGWU_ASR
-    if settings.ASR_PROVIDER.lower() == "tingwu" and settings.DASHSCOPE_API_KEY:
-        if _SDK_TINGWU_ASR is None:
-            try:
-                _SDK_TINGWU_ASR = SDKTingWuASR(settings)
-            except Exception as exc:  # pragma: no cover - configuration guard
-                LOGGER.warning("Failed to initialise SDKTingWuASR: %s", exc)
-                return DEFAULT_ASR
-        return _SDK_TINGWU_ASR
-    return DEFAULT_ASR
+def _provider() -> StubASR | TingwuClientASR:
+    global _TINGWU_CLIENT_ASR
+    if _TINGWU_CLIENT_ASR is None:
+        try:
+            _TINGWU_CLIENT_ASR = TingwuClientASR(settings)
+        except Exception as exc:  # pragma: no cover - configuration guard
+            LOGGER.warning("Failed to initialise TingwuClientASR: %s", exc)
+            return DEFAULT_ASR
+    return _TINGWU_CLIENT_ASR
 
 
 def transcribe(
@@ -177,12 +122,12 @@ def transcribe(
         return DEFAULT_ASR.transcribe(text=text, audio_ref=audio_ref)
 
 
-TingWuASR = SDKTingWuASR
+TingWuASR = TingwuClientASR
 
 __all__ = [
     "AsrError",
     "StubASR",
-    "SDKTingWuASR",
+    "TingwuClientASR",
     "TingWuASR",
     "transcribe",
 ]

--- a/services/orchestrator/langgraph_min.py
+++ b/services/orchestrator/langgraph_min.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from packages.common.config import settings
-from services.audio.asr_adapter import AsrError, StubASR
+from services.audio.asr_adapter import AsrError, StubASR, TingwuClientASR
 from services.risk.engine import engine as risk_engine
 from services.store.repository import repository
 
@@ -88,17 +88,12 @@ class LangGraphMini:
         self.window_n = self._read_int_env("WINDOW_N", default=8)
         self.window_seconds = self._read_int_env("WINDOW_SECONDS", default=90)
         self.stub_asr = StubASR()
-        if settings.ASR_PROVIDER == "tingwu":
-            try:
-                from services.audio.asr_adapter import SDKTingWuASR
-
-                self.asr = SDKTingWuASR(settings)
-            except Exception as exc:  # pragma: no cover - configuration guard
-                LOGGER.warning(
-                    "Failed to initialise SDKTingWuASR, using stub instead: %s", exc
-                )
-                self.asr = self.stub_asr
-        else:
+        try:
+            self.asr = TingwuClientASR(settings)
+        except Exception as exc:  # pragma: no cover - configuration guard
+            LOGGER.warning(
+                "Failed to initialise TingwuClientASR, using stub instead: %s", exc
+            )
             self.asr = self.stub_asr
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace the DashScope-based ASR adapter with a lightweight Tingwu client wrapper
- update the LangGraph orchestrator to initialise the new adapter while keeping the text stub fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b23734e083249fc3b380f9195324