### PR TITLE
Improve DeepSeek diagnostics and controller fallback handling

### DIFF
--- a/services/orchestrator/langgraph_min.py
+++ b/services/orchestrator/langgraph_min.py
@@ -60,6 +60,8 @@ class SessionState:
     opinion: Optional[str] = None
     last_text: str = ""
     analysis: Optional[Dict[str, Any]] = None
+    controller_notice_logged: bool = False
+    controller_unusable_turn: Optional[int] = None
 
 
 class LangGraphMini:
@@ -190,12 +192,67 @@ class LangGraphMini:
         dialogue_payload = self._build_dialogue_payload(sid)
         current_progress = {"index": item_id, "total": TOTAL_ITEMS}
 
+        controller_enabled = settings.ENABLE_DS_CONTROLLER and self.deepseek.enabled()
+
+        if not controller_enabled:
+            if not state.controller_notice_logged:
+                reason = (
+                    "disabled via settings"
+                    if not settings.ENABLE_DS_CONTROLLER
+                    else "client not configured"
+                )
+                LOGGER.info("DeepSeek controller unavailable for %s: %s", sid, reason)
+                state.controller_notice_logged = True
+                self._persist_state(state)
+            return self._fallback_flow(
+                sid=sid,
+                state=state,
+                item_id=item_id,
+                scoring_segments=scoring_segments,
+                dialogue=dialogue_payload,
+                transcripts=transcripts,
+                user_text=user_text,
+            )
+
+        if (
+            state.controller_unusable_turn is not None
+            and state.controller_unusable_turn == state.last_utt_index
+        ):
+            LOGGER.debug(
+                "DeepSeek controller temporarily sidelined for %s on turn %s",
+                sid,
+                state.controller_unusable_turn,
+            )
+            return self._fallback_flow(
+                sid=sid,
+                state=state,
+                item_id=item_id,
+                scoring_segments=scoring_segments,
+                dialogue=dialogue_payload,
+                transcripts=transcripts,
+                user_text=user_text,
+            )
+
         decision: Optional[ControllerDecision] = None
-        if settings.ENABLE_DS_CONTROLLER and self.deepseek.enabled():
-            try:
-                decision = self.deepseek.plan_turn(dialogue_payload, current_progress)
-            except Exception as exc:  # pragma: no cover - runtime guard
-                LOGGER.warning("DeepSeek controller planning failed: %s", exc)
+        try:
+            decision = self.deepseek.plan_turn(dialogue_payload, current_progress)
+        except Exception as exc:  # pragma: no cover - runtime guard
+            log_method = LOGGER.warning
+            if state.controller_notice_logged:
+                log_method = LOGGER.debug
+            log_method("DeepSeek controller planning failed for %s: %s", sid, exc)
+            state.controller_notice_logged = True
+            state.controller_unusable_turn = state.last_utt_index
+            self._persist_state(state)
+            return self._fallback_flow(
+                sid=sid,
+                state=state,
+                item_id=item_id,
+                scoring_segments=scoring_segments,
+                dialogue=dialogue_payload,
+                transcripts=transcripts,
+                user_text=user_text,
+            )
 
         if decision and decision.hamd_partial:
             analysis_payload = decision.hamd_partial.model_dump()
@@ -211,6 +268,8 @@ class LangGraphMini:
             analysis_payload = None
 
         if not decision:
+            state.controller_unusable_turn = state.last_utt_index
+            self._persist_state(state)
             return self._fallback_flow(
                 sid=sid,
                 state=state,
@@ -223,6 +282,10 @@ class LangGraphMini:
 
         if analysis_payload:
             state.analysis = analysis_payload
+
+        if state.controller_unusable_turn is not None:
+            state.controller_unusable_turn = None
+            self._persist_state(state)
 
         extra: Dict[str, Any] = {}
         if state.analysis:
@@ -726,6 +789,13 @@ class LangGraphMini:
         state.scores_acc = raw.get("scores_acc", state.scores_acc)
         state.last_text = raw.get("last_text", state.last_text)
         state.analysis = raw.get("analysis", state.analysis)
+        state.controller_notice_logged = bool(
+            raw.get("controller_notice_logged", state.controller_notice_logged)
+        )
+        controller_turn = raw.get("controller_unusable_turn")
+        state.controller_unusable_turn = (
+            int(controller_turn) if controller_turn is not None else None
+        )
         return state
 
     def _persist_state(self, state: SessionState) -> None:
@@ -741,6 +811,8 @@ class LangGraphMini:
                 "opinion": state.opinion,
                 "last_text": state.last_text,
                 "analysis": state.analysis,
+                "controller_notice_logged": state.controller_notice_logged,
+                "controller_unusable_turn": state.controller_unusable_turn,
             },
         )
 


### PR DESCRIPTION
## Summary
- add instrumentation to the DeepSeek JSON client to flag misconfigured API bases and log HTTP response bodies when failures occur
- track controller availability within each session so we only log once per session and temporarily sideline the controller when DeepSeek planning fails

## Testing
- python scripts/test_controller_flow.py *(fails: file not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e298a193048324b70ead46a0345153