### PR TITLE
Expose Prometheus metrics under alternative path

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -24,6 +24,7 @@ def health() -> JSONResponse:
 
 
 @app.get("/metrics")
+@app.get("/-/metrics")
 def metrics() -> Response:
     data = generate_latest(_registry)
     return Response(content=data, media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- expose the existing Prometheus metrics handler via the `/-/metrics` endpoint to match `/metrics`

## Testing
- python -m compileall apps/api/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e31ad0440c8324838765228f433007