### PR TITLE
Refine risk handling and add regression scripts

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -24,6 +24,7 @@ def health() -> JSONResponse:
 
 
 @app.get("/metrics")
+@app.get("/-/metrics")
 def metrics() -> Response:
     data = generate_latest(_registry)
     return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/scripts/test_flow_ok.sh
+++ b/scripts/test_flow_ok.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+API="http://127.0.0.1:8080"
+SID="flow_ok_1"
+
+step() {
+  echo -e "\n=== $1 ==="
+}
+
+step "首问"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\"}" | jq .
+sleep 0.3
+
+step "item1"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\",\"text\":\"最近心情不好，每周三四天，持续半天到一天。\"}" | jq .
+sleep 0.3
+
+step "item2"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\",\"text\":\"对原本喜欢的事情兴趣下降，多数天都提不起劲。\"}" | jq .
+sleep 0.3
+
+step "item3（明确否定）"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\",\"text\":\"没有自杀想法，也不会做伤害自己的事。\"}" | jq .

--- a/scripts/test_flow_risk_release.sh
+++ b/scripts/test_flow_risk_release.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+API="http://127.0.0.1:8080"
+SID="flow_risk_release_1"
+
+step() {
+  echo -e "\n=== $1 ==="
+}
+
+step "首问"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\"}" | jq .
+sleep 0.3
+
+step "触发高风险（示例）"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\",\"text\":\"有时候会想自杀。\"}" | jq .
+sleep 0.3
+
+step "解除风险（明确否定+说明已安全）"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\",\"text\":\"我现在已经安全，不需要紧急帮助，没有自杀想法。\"}" | jq .
+sleep 0.3
+
+step "继续下一题（验证能前进）"
+curl -s -X POST "$API/dm/step" -H 'Content-Type: application/json' \
+  -d "{\"sid\":\"$SID\",\"role\":\"user\",\"text\":\"最近入睡困难，上床后要40分钟才能睡着。\"}" | jq .

--- a/services/risk/engine.py
+++ b/services/risk/engine.py
@@ -1,13 +1,64 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
+
+import re
+
+
+NEGATION_PATTERNS = [
+    re.compile(pattern)
+    for pattern in [
+        r"没有",
+        r"並?不",
+        r"并?不",
+        r"不再",
+        r"不想",
+        r"不会",
+        r"不會",
+        r"从未",
+        r"沒打算",
+        r"没打算",
+        r"否认",
+        r"無",
+    ]
+]
+
+NEGATION_WINDOW = 6
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", "", text or "")
+
+
+def is_negated(text: str, trigger: str) -> bool:
+    """Return True when the trigger appears near a negation cue."""
+
+    normalized = _normalize(text)
+    if not trigger:
+        return False
+    try:
+        pattern = re.compile(re.escape(trigger))
+    except re.error:
+        return False
+
+    has_match = False
+    for match in pattern.finditer(normalized):
+        has_match = True
+        start, end = match.span()
+        left = normalized[max(0, start - NEGATION_WINDOW) : start]
+        right = normalized[end : min(len(normalized), end + NEGATION_WINDOW)]
+        window = f"{left}{right}"
+        if not any(pat.search(window) for pat in NEGATION_PATTERNS):
+            return False
+    return has_match
 
 
 @dataclass
 class RiskAssessment:
     level: str
     triggers: List[str]
+    reason: Optional[str] = None
 
 
 class RiskEngine:
@@ -23,10 +74,25 @@ class RiskEngine:
         ]
 
     def evaluate(self, text: str) -> RiskAssessment:
-        hits = [kw for kw in self._high_risk_keywords if kw in text]
+        normalized = _normalize(text)
+        if not normalized:
+            return RiskAssessment(level="low", triggers=[], reason=None)
+
+        hits: List[str] = []
+        for keyword in self._high_risk_keywords:
+            if keyword not in normalized:
+                continue
+            if is_negated(text, keyword):
+                continue
+            hits.append(keyword)
+
         if hits:
-            return RiskAssessment(level="high", triggers=hits)
-        return RiskAssessment(level="low", triggers=[])
+            return RiskAssessment(
+                level="high",
+                triggers=hits,
+                reason="positive_trigger_no_negation",
+            )
+        return RiskAssessment(level="low", triggers=[], reason="no_trigger")
 
 
 engine = RiskEngine()


### PR DESCRIPTION
## Summary
- add near-distance negation detection to the risk engine and expose trigger reasons
- keep the orchestrator in a risk hold state with explicit release handling and event logging
- add regression scripts that cover a safe flow and a risk hold followed by release

## Testing
- python -m compileall services/risk/engine.py services/orchestrator/langgraph_min.py

------
https://chatgpt.com/codex/tasks/task_e_68e31ad0440c8324838765228f433007