### PR TITLE
Add DeepSeek timeout circuit breaker

### DIFF
--- a/services/llm/json_client.py
+++ b/services/llm/json_client.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
+from time import monotonic
 from pydantic import BaseModel, Field
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -22,6 +23,11 @@ from services.orchestrator.gap_utils import GAP_LABELS, detect_information_gaps
 from services.orchestrator.questions_hamd17 import HAMD17_QUESTION_BANK
 
 LOGGER = logging.getLogger(__name__)
+
+
+class DeepSeekTemporarilyUnavailableError(RuntimeError):
+    """Raised when the DeepSeek client is temporarily unavailable."""
+    pass
 
 
 class HAMDItem(BaseModel):
@@ -78,6 +84,7 @@ class DeepSeekJSONClient:
         self.key = key or settings.deepseek_api_key
         self.model = model or os.getenv("DEEPSEEK_MODEL", "deepseek-chat")
         self._warned_bad_base = False
+        self._circuit_open_until: Optional[float] = None
         trimmed_base = (self.base or "").rstrip("/")
         if trimmed_base and not trimmed_base.endswith("/v1"):
             LOGGER.warning(
@@ -92,6 +99,23 @@ class DeepSeekJSONClient:
     def enabled(self) -> bool:
         return bool(self.base and self.key)
 
+    def usable(self) -> bool:
+        return self.enabled() and not self._is_circuit_open()
+
+    def _is_circuit_open(self) -> bool:
+        if self._circuit_open_until is None:
+            return False
+        if monotonic() >= self._circuit_open_until:
+            self._circuit_open_until = None
+            return False
+        return True
+
+    def _trip_circuit(self, duration: float = 45.0) -> None:
+        if duration <= 0:
+            self._circuit_open_until = None
+            return
+        self._circuit_open_until = monotonic() + duration
+
     @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
     def _post_chat(
         self,
@@ -104,6 +128,12 @@ class DeepSeekJSONClient:
     ) -> str:
         if not self.enabled():  # pragma: no cover - guard rail
             raise RuntimeError("DeepSeek client not configured")
+
+        if self._is_circuit_open():
+            remaining = max(self._circuit_open_until - monotonic(), 0) if self._circuit_open_until else 0
+            raise DeepSeekTemporarilyUnavailableError(
+                f"DeepSeek client temporarily disabled (retry in {remaining:.1f}s)"
+            )
 
         url_base = (self.base or "").strip()
         trimmed_base = url_base.rstrip("/")
@@ -171,9 +201,16 @@ class DeepSeekJSONClient:
                 raise
             except httpx.RequestError as exc:
                 LOGGER.error("DeepSeek chat request errored: %s", exc)
+                read_timeout_cls = getattr(httpx, "ReadTimeout", None)
+                if read_timeout_cls and isinstance(exc, read_timeout_cls):
+                    self._trip_circuit()
+                    raise DeepSeekTemporarilyUnavailableError(
+                        "DeepSeek timed out and is temporarily unavailable"
+                    ) from exc
                 raise
 
             data = response.json()
+            self._circuit_open_until = None
             return data["choices"][0]["message"]["content"]
 
     def analyze(
@@ -181,6 +218,10 @@ class DeepSeekJSONClient:
         dialogue_json: List[dict],
         system_prompt: Optional[str] = None,
     ) -> HAMDResult:
+        if not self.usable():
+            raise DeepSeekTemporarilyUnavailableError(
+                "DeepSeek analyze skipped because the client is temporarily unavailable"
+            )
         prompt = system_prompt or get_prompt_hamd17()
         messages = [
             {"role": "system", "content": prompt},
@@ -193,6 +234,8 @@ class DeepSeekJSONClient:
             )
             parsed = json.loads(content)
             return HAMDResult.model_validate(parsed)
+        except DeepSeekTemporarilyUnavailableError:
+            raise
         except Exception as exc:  # pragma: no cover - runtime guard
             LOGGER.warning("DeepSeek analyze failed: %s", exc)
 
@@ -284,6 +327,8 @@ class DeepSeekJSONClient:
                     text = text.split(end)[0] + end
                     break
             return text[:30] if text else None
+        except DeepSeekTemporarilyUnavailableError:
+            return None
         except Exception as exc:  # pragma: no cover - runtime guard
             LOGGER.warning("DeepSeek clarify generation failed: %s", exc)
             return None
@@ -293,6 +338,10 @@ class DeepSeekJSONClient:
         dialogue_json: List[dict],
         progress: dict,
     ) -> ControllerDecision:
+        if not self.usable():
+            raise DeepSeekTemporarilyUnavailableError(
+                "DeepSeek controller planning skipped because the client is temporarily unavailable"
+            )
         prompt = get_prompt_hamd17_controller()
         messages = [
             {"role": "system", "content": prompt},
@@ -323,6 +372,7 @@ client = DeepSeekJSONClient()
 
 __all__ = [
     "DeepSeekJSONClient",
+    "DeepSeekTemporarilyUnavailableError",
     "HAMDItem",
     "HAMDResult",
     "HAMDTotal",

--- a/services/orchestrator/langgraph_min.py
+++ b/services/orchestrator/langgraph_min.py
@@ -5,17 +5,21 @@ import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from packages.common.config import settings
 from services.audio.asr_adapter import AsrError, StubASR, TingwuClientASR
-from services.llm.json_client import ControllerDecision, DeepSeekJSONClient, HAMDResult
+from services.llm.json_client import (
+    ControllerDecision,
+    DeepSeekJSONClient,
+    DeepSeekTemporarilyUnavailableError,
+    HAMDResult,
+)
 from services.llm.prompts import (
     get_prompt_hamd17,
     get_prompt_diagnosis,
     get_prompt_mdd_judgment,
 )
-from services.orchestrator.gap_utils import GAP_LABELS, detect_information_gaps
 from services.orchestrator.questions_hamd17 import (
     MAX_SCORE,
     get_first_item,
@@ -61,20 +65,6 @@ RISK_RELEASE_PATTERNS = [
         r"不会伤害自己",
         r"不會傷害自己",
     ]
-]
-
-VAGUE_PHRASES = [
-    "还好",
-    "一般",
-    "差不多",
-    "说不清",
-    "不好说",
-    "看情况",
-    "可能吧",
-    "偶尔吧",
-    "有点吧",
-    "还行",
-    "凑合",
 ]
 
 
@@ -229,14 +219,20 @@ class LangGraphMini:
         dialogue_payload = self._build_dialogue_payload(sid)
         current_progress = {"index": item_id, "total": TOTAL_ITEMS}
 
-        controller_enabled = settings.ENABLE_DS_CONTROLLER and self.deepseek.enabled()
+        controller_enabled = (
+            settings.ENABLE_DS_CONTROLLER and self.deepseek.usable()
+        )
 
         if not controller_enabled:
             if not state.controller_notice_logged:
                 reason = (
                     "disabled via settings"
                     if not settings.ENABLE_DS_CONTROLLER
-                    else "client not configured"
+                    else (
+                        "client not configured"
+                        if not self.deepseek.enabled()
+                        else "temporarily unavailable"
+                    )
                 )
                 LOGGER.info("DeepSeek controller unavailable for %s: %s", sid, reason)
                 state.controller_notice_logged = True
@@ -273,6 +269,20 @@ class LangGraphMini:
         decision: Optional[ControllerDecision] = None
         try:
             decision = self.deepseek.plan_turn(dialogue_payload, current_progress)
+        except DeepSeekTemporarilyUnavailableError as exc:
+            LOGGER.debug("DeepSeek controller temporarily unavailable for %s: %s", sid, exc)
+            state.controller_notice_logged = True
+            state.controller_unusable_turn = state.last_utt_index
+            self._persist_state(state)
+            return self._fallback_flow(
+                sid=sid,
+                state=state,
+                item_id=item_id,
+                scoring_segments=scoring_segments,
+                dialogue=dialogue_payload,
+                transcripts=transcripts,
+                user_text=user_text,
+            )
         except Exception as exc:  # pragma: no cover - runtime guard
             log_method = LOGGER.warning
             if state.controller_notice_logged:
@@ -649,11 +659,50 @@ class LangGraphMini:
         self,
         state: SessionState,
         transcripts: List[Dict[str, Any]],
+        dialogue: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[Dict[str, Any]]:
         if not transcripts:
             return None
 
+        semantic_result = self._semantic_score_current_item(
+            state, transcripts, dialogue
+        )
+        if semantic_result:
+            return semantic_result
+
+        return None
+
+    def _semantic_score_current_item(
+        self,
+        state: SessionState,
+        transcripts: List[Dict[str, Any]],
+        dialogue: Optional[List[Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        if not self.deepseek.usable():
+            return None
+
+        dialogue_payload = list(dialogue) if dialogue else self._build_dialogue_payload(
+            state.sid
+        )
+        if not dialogue_payload:
+            return None
+
+        try:
+            result = self.deepseek.analyze(dialogue_payload, get_prompt_hamd17())
+        except DeepSeekTemporarilyUnavailableError as exc:
+            LOGGER.debug("DeepSeek semantic scoring skipped for %s: %s", state.sid, exc)
+            return None
+        except Exception as exc:  # pragma: no cover - runtime guard
+            LOGGER.debug(
+                "DeepSeek semantic scoring skipped for %s: %s", state.sid, exc
+            )
+            return None
+
         item_id = self._current_item_id(state)
+        target = next((item for item in result.items if item.item_id == item_id), None)
+        if target is None:
+            return None
+
         question = pick_primary(item_id)
         latest_segment = next(
             (
@@ -663,17 +712,24 @@ class LangGraphMini:
             ),
             transcripts[-1],
         )
-        text = str(latest_segment.get("text", ""))
-        score = self._rule_based_score(text, item_id)
-        evidence_refs = [latest_segment.get("utt_id", "")]
+        evidence_refs = [ref for ref in target.evidence_refs if ref]
+        if not evidence_refs and latest_segment:
+            evidence_id = latest_segment.get("utt_id", "")
+            if evidence_id:
+                evidence_refs = [evidence_id]
 
-        per_item_score = {
+        per_item_score: Dict[str, Any] = {
             "item_id": f"H{item_id:02d}",
             "name": question,
             "question": question,
-            "score": score,
+            "score": min(int(target.score), MAX_SCORE.get(item_id, 4)),
             "max_score": MAX_SCORE.get(item_id, 4),
             "evidence_refs": evidence_refs,
+            "score_type": target.score_type,
+            "score_reason": target.score_reason,
+            "dialogue_evidence": target.dialogue_evidence,
+            "symptom_summary": target.symptom_summary,
+            "clarify_need": target.clarify_need,
         }
 
         opinion = self._generate_opinion(state.scores_acc, per_item_score)
@@ -682,22 +738,6 @@ class LangGraphMini:
             "per_item_scores": [per_item_score],
             "opinion": opinion,
         }
-
-    def _rule_based_score(self, text: str, item_id: int) -> int:
-        normalized = text.strip()
-        lowered = normalized.lower()
-        max_score = MAX_SCORE.get(item_id, 4)
-        if not normalized:
-            return 0
-        if any(keyword in normalized for keyword in ["没有", "不", "很少", "没"]):
-            return 0
-        if any(keyword in normalized for keyword in ["严重", "完全", "一直", "难以"]):
-            return min(4, max_score)
-        if any(keyword in lowered for keyword in ["经常", "很多", "每天", "总是"]):
-            return min(3, max_score)
-        if any(keyword in lowered for keyword in ["有时", "偶尔", "有点", "几天"]):
-            return min(2, max_score)
-        return 1 if max_score >= 1 else 0
 
     def _merge_scores(self, state: SessionState, new_scores: List[Dict[str, Any]]) -> None:
         scores_by_id = {score["item_id"]: score for score in state.scores_acc}
@@ -764,9 +804,6 @@ class LangGraphMini:
             turn_type="complete",
         )
 
-    def _detect_gaps(self, state: SessionState, item_id: int) -> List[str]:
-        return detect_information_gaps(state.last_text, item_id=item_id)
-
     def _fallback_flow(
         self,
         *,
@@ -788,15 +825,20 @@ class LangGraphMini:
             self._store_analysis_scores(sid, state, analysis_result)
         else:
             state.analysis = None
-            score_result = self._score_current_item(state, scoring_segments)
+            score_result = self._score_current_item(state, scoring_segments, dialogue)
             if score_result:
                 self._merge_scores(state, score_result["per_item_scores"])
                 state.opinion = score_result.get("opinion") or state.opinion
 
-        reverse_gap_labels = {label: key for key, label in GAP_LABELS.items()}
-        fallback_gaps = self._detect_gaps(state, item_id)
+        active_clarify_need: Optional[str] = None
+        if analysis_result:
+            target_item = next(
+                (item for item in analysis_result.items if item.item_id == item_id),
+                None,
+            )
+            if target_item:
+                active_clarify_need = target_item.clarify_need or None
 
-        stored_gap_key: Optional[str] = None
         try:
             last_clarify = self.repo.get_last_clarify_need(sid)
         except Exception:  # pragma: no cover - runtime guard
@@ -805,41 +847,27 @@ class LangGraphMini:
 
         if last_clarify and last_clarify.get("item_id") == item_id:
             stored_need = last_clarify.get("need")
-            if isinstance(stored_need, str):
-                stored_gap_key = reverse_gap_labels.get(stored_need, stored_need)
-            if stored_gap_key and stored_gap_key not in fallback_gaps:
+            if not active_clarify_need or stored_need != active_clarify_need:
                 try:
                     self.repo.clear_last_clarify_need(sid)
                 except Exception:  # pragma: no cover - runtime guard
                     LOGGER.exception("Failed to clear clarify target for %s", sid)
-                stored_gap_key = None
 
-        if not analysis_result and user_text and state.clarify < 2:
-            if self._is_vague(user_text) or fallback_gaps:
-                state.clarify += 1
-                clarify_key = fallback_gaps[0] if fallback_gaps else "severity"
-                clarify_label = GAP_LABELS.get(clarify_key, clarify_key)
-                try:
-                    self.repo.set_last_clarify_need(sid, item_id, clarify_label)
-                except Exception:  # pragma: no cover - runtime guard
-                    LOGGER.exception("Failed to persist clarify target for %s", sid)
-                clarify_prompt = pick_clarify(item_id, clarify_key)
-                self._persist_state(state)
-                return self._make_response(
-                    sid,
-                    state,
-                    clarify_prompt,
-                    turn_type="clarify",
-                    extra=extra_payload,
-                )
-
-        clarify_question = None
+        clarify_payload: Optional[Tuple[str, int, str]] = None
         if analysis_result and user_text and state.clarify < 2:
-            clarify_question = self._clarify_from_analysis(
+            clarify_payload = self._clarify_from_analysis(
                 state, analysis_result, dialogue
             )
 
-        if clarify_question:
+        if clarify_payload:
+            clarify_question, clarify_item_id, clarify_need = clarify_payload
+            if clarify_need:
+                try:
+                    self.repo.set_last_clarify_need(
+                        sid, clarify_item_id, clarify_need
+                    )
+                except Exception:  # pragma: no cover - runtime guard
+                    LOGGER.exception("Failed to persist clarify target for %s", sid)
             state.clarify += 1
             self._persist_state(state)
             return self._make_response(
@@ -978,17 +1006,6 @@ class LangGraphMini:
             LOGGER.warning("Invalid value for %s: %s; using default %s", name, raw, default)
             return default
 
-    @staticmethod
-    def _is_vague(text: str) -> bool:
-        if not text:
-            return False
-        normalized = re.sub(r"[\s\W]+", "", text, flags=re.UNICODE).lower()
-        for phrase in VAGUE_PHRASES:
-            phrase_norm = re.sub(r"[\s\W]+", "", phrase, flags=re.UNICODE).lower()
-            if phrase_norm and phrase_norm in normalized:
-                return True
-        return False
-
     def _generate_opinion(
         self, existing_scores: List[Dict[str, Any]], new_score: Dict[str, Any]
     ) -> str:
@@ -1028,12 +1045,15 @@ class LangGraphMini:
         return dialogue
 
     def _run_deepseek_analysis(self, dialogue: List[Dict[str, Any]]) -> Optional[HAMDResult]:
-        if not dialogue or len(dialogue) < 4:
+        if not dialogue:
             return None
-        if not self.deepseek.enabled():
+        if not self.deepseek.usable():
             return None
         try:
             return self.deepseek.analyze(dialogue, get_prompt_hamd17())
+        except DeepSeekTemporarilyUnavailableError as exc:
+            LOGGER.debug("DeepSeek analysis temporarily unavailable: %s", exc)
+            return None
         except Exception as exc:  # pragma: no cover - runtime guard
             LOGGER.warning("DeepSeek analysis skipped: %s", exc)
             return None
@@ -1068,7 +1088,7 @@ class LangGraphMini:
         state: SessionState,
         result: HAMDResult,
         dialogue: List[Dict[str, Any]],
-    ) -> Optional[str]:
+    ) -> Optional[Tuple[str, int, str]]:
         current_item = self._current_item_id(state)
         target = next(
             (
@@ -1090,7 +1110,7 @@ class LangGraphMini:
             [entry.get("text", "") for entry in dialogue if entry.get("role") == "user"][-2:]
         )
         question = None
-        if self.deepseek.enabled():
+        if self.deepseek.usable():
             question = self.deepseek.gen_clarify_question(
                 target.item_id,
                 self.ITEM_NAMES.get(target.item_id, f"条目{target.item_id}"),
@@ -1099,7 +1119,7 @@ class LangGraphMini:
             )
         if not question:
             question = self.CLARIFY_FALLBACKS.get(clarify_need, "能再具体说说这个情况吗？")
-        return question
+        return question, target.item_id, clarify_need
 
 
 orchestrator = LangGraphMini()


### PR DESCRIPTION
## Summary
- add a DeepSeek client circuit breaker that marks the service temporarily unavailable after read timeouts and surfaces the state to callers
- ensure the orchestrator skips controller planning, semantic scoring, and clarify generation while the DeepSeek circuit is open and falls back immediately
- extend DeepSeek client tests to cover the circuit breaker behaviour

## Testing
- pytest tests/test_deepseek_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e34bb0383883249c86d004811e620c