### PR TITLE
Cache DashScope synthesizers between TTS calls

### DIFF
--- a/packages/common/config.py
+++ b/packages/common/config.py
@@ -17,11 +17,18 @@ class Settings(BaseSettings):
     redis_password: Optional[str] = Field(None, alias="REDIS_PASSWORD")
     deepseek_api_base: Optional[str] = Field(None, alias="DEEPSEEK_API_BASE")
     deepseek_api_key: Optional[str] = Field(None, alias="DEEPSEEK_API_KEY")
+    dashscope_api_key: Optional[str] = Field(None, alias="DASHSCOPE_API_KEY")
+    dashscope_tts_model: str = Field("cosyvoice-v2", alias="DASHSCOPE_TTS_MODEL")
+    dashscope_tts_voice: str = Field("longxiaochun_v2", alias="DASHSCOPE_TTS_VOICE")
+    dashscope_tts_format: str = Field("wav", alias="DASHSCOPE_TTS_FORMAT")
     prompt_hamd17_path: Optional[str] = Field(None, alias="PROMPT_HAMD17_PATH")
     prompt_diagnosis_path: Optional[str] = Field(None, alias="PROMPT_DIAGNOSIS_PATH")
     prompt_mdd_judgment_path: Optional[str] = Field(None, alias="PROMPT_MDD_JUDGMENT_PATH")
     prompt_clarify_cn_path: Optional[str] = Field(None, alias="PROMPT_CLARIFY_CN_PATH")
     enable_ds_controller: bool = Field(True, alias="ENABLE_DS_CONTROLLER")
+    deepseek_chat_timeout: float = Field(90.0, alias="DEEPSEEK_CHAT_TIMEOUT")
+    deepseek_clarify_timeout: float = Field(60.0, alias="DEEPSEEK_CLARIFY_TIMEOUT")
+    deepseek_controller_timeout: float = Field(90.0, alias="DEEPSEEK_CONTROLLER_TIMEOUT")
     alibaba_cloud_access_key_id: Optional[str] = Field(
         None, alias="ALIBABA_CLOUD_ACCESS_KEY_ID"
     )
@@ -119,6 +126,22 @@ class Settings(BaseSettings):
         return self.deepseek_api_key
 
     @property
+    def DASHSCOPE_API_KEY(self) -> Optional[str]:
+        return self.dashscope_api_key
+
+    @property
+    def DASHSCOPE_TTS_MODEL(self) -> str:
+        return self.dashscope_tts_model
+
+    @property
+    def DASHSCOPE_TTS_VOICE(self) -> str:
+        return self.dashscope_tts_voice
+
+    @property
+    def DASHSCOPE_TTS_FORMAT(self) -> str:
+        return self.dashscope_tts_format
+
+    @property
     def PROMPT_HAMD17_PATH(self) -> Optional[str]:
         return self.prompt_hamd17_path
 
@@ -137,6 +160,18 @@ class Settings(BaseSettings):
     @property
     def ENABLE_DS_CONTROLLER(self) -> bool:
         return self.enable_ds_controller
+
+    @property
+    def DEEPSEEK_CHAT_TIMEOUT(self) -> float:
+        return self.deepseek_chat_timeout
+
+    @property
+    def DEEPSEEK_CLARIFY_TIMEOUT(self) -> float:
+        return self.deepseek_clarify_timeout
+
+    @property
+    def DEEPSEEK_CONTROLLER_TIMEOUT(self) -> float:
+        return self.deepseek_controller_timeout
 
     class Config:
         env_file = ".env"

--- a/services/orchestrator/langgraph_min.py
+++ b/services/orchestrator/langgraph_min.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from packages.common.config import settings
 from services.audio.asr_adapter import AsrError, StubASR, TingwuClientASR
-from services.llm.json_client import ControllerDecision, DeepSeekJSONClient, HAMDResult
+from services.llm.json_client import (
+    ControllerDecision,
+    DeepSeekJSONClient,
+    DeepSeekTemporarilyUnavailableError,
+    HAMDResult,
+)
 from services.llm.prompts import (
     get_prompt_hamd17,
     get_prompt_diagnosis,
     get_prompt_mdd_judgment,
 )
-from services.orchestrator.gap_utils import GAP_LABELS, detect_information_gaps
 from services.orchestrator.questions_hamd17 import (
     MAX_SCORE,
     get_first_item,
@@ -25,6 +30,7 @@ from services.orchestrator.questions_hamd17 import (
 )
 from services.risk.engine import engine as risk_engine
 from services.store.repository import repository
+from services.report.build import build_pdf
 from services.tts.tts_adapter import TTSAdapter
 
 LOGGER = logging.getLogger(__name__)
@@ -38,6 +44,16 @@ RISK_HOLD_REMINDER_TEXT = (
 )
 MISSING_INPUT_PROMPT = "未获取音频/文本，请重新描述一次好吗？"
 COMPLETION_TEXT = "本次评估完成，感谢配合。稍后可下载报告。"
+
+REPORT_REQUEST_PATTERNS = [
+    re.compile(pattern)
+    for pattern in [
+        r"(获取|生成|下载|查看|打印|要|想要).{0,6}报告",
+        r"报告.{0,6}(怎么|如何|咋|怎样).{0,4}(获取|生成|下载)",
+        r"出一份报告",
+        r"报告给我",
+    ]
+]
 
 RISK_RELEASE_PATTERNS = [
     re.compile(pattern)
@@ -61,20 +77,6 @@ RISK_RELEASE_PATTERNS = [
         r"不会伤害自己",
         r"不會傷害自己",
     ]
-]
-
-VAGUE_PHRASES = [
-    "还好",
-    "一般",
-    "差不多",
-    "说不清",
-    "不好说",
-    "看情况",
-    "可能吧",
-    "偶尔吧",
-    "有点吧",
-    "还行",
-    "凑合",
 ]
 
 
@@ -115,14 +117,6 @@ class LangGraphMini:
         self.deepseek = DeepSeekJSONClient()
         self.prompt_diagnosis = get_prompt_diagnosis
         self.prompt_mdd = get_prompt_mdd_judgment
-        self.CLARIFY_FALLBACKS = {
-            "频次": "这种情况大概一周发生几次？",
-            "持续时间": "每次大约持续多长时间？",
-            "严重程度": "这对你的日常影响有多大？",
-            "是否否定": "最近两周是否基本没有这种情况？",
-            "是否有计划": "是否有具体计划或准备过相关工具？",
-            "安全保障": "现在身边是否有人陪伴，能保证你的安全？",
-        }
         self.ITEM_NAMES = {
             1: "抑郁情绪",
             2: "有罪感",
@@ -142,6 +136,20 @@ class LangGraphMini:
             16: "体重减轻",
             17: "自知力",
         }
+
+    # ------------------------------------------------------------------
+    def _has_asked_any_primary(self, sid: str) -> bool:
+        """Return True if the session already contains an assistant 'ask' turn."""
+        try:
+            transcripts = self.repo.get_transcripts(sid)
+        except Exception:  # pragma: no cover - defensive guard
+            return False
+        for segment in transcripts or []:
+            role = segment.get("role") or segment.get("speaker")
+            turn_type = segment.get("type")
+            if role in {"assistant", "bot"} and turn_type == "ask":
+                return True
+        return False
 
     # ------------------------------------------------------------------
     def ask(self, sid: str) -> Dict[str, object]:
@@ -172,9 +180,11 @@ class LangGraphMini:
         if state.completed:
             return self._complete_payload(state, COMPLETION_TEXT)
 
+        asked_primary = self._has_asked_any_primary(sid)
+
         if not text and not audio_ref:
-            item = get_first_item()
-            question = pick_primary(item)
+            # 沿用当前条目，不要重置回首问
+            question = pick_primary(self._current_item_id(state))
             response = self._make_response(
                 sid,
                 state,
@@ -221,6 +231,19 @@ class LangGraphMini:
         if user_text:
             state.last_text = user_text
 
+        report_payload = self._maybe_handle_report_request(sid, state, user_text)
+        if report_payload is not None:
+            return report_payload
+
+        if not asked_primary:
+            question = pick_primary(self._current_item_id(state))
+            return self._make_response(
+                sid,
+                state,
+                question,
+                turn_type="ask",
+            )
+
         item_id = self._current_item_id(state)
         scoring_segments = self._latest_segments(
             transcripts, self.window_n, self.window_seconds
@@ -229,14 +252,20 @@ class LangGraphMini:
         dialogue_payload = self._build_dialogue_payload(sid)
         current_progress = {"index": item_id, "total": TOTAL_ITEMS}
 
-        controller_enabled = settings.ENABLE_DS_CONTROLLER and self.deepseek.enabled()
+        controller_enabled = (
+            settings.ENABLE_DS_CONTROLLER and self.deepseek.usable()
+        )
 
         if not controller_enabled:
             if not state.controller_notice_logged:
                 reason = (
                     "disabled via settings"
                     if not settings.ENABLE_DS_CONTROLLER
-                    else "client not configured"
+                    else (
+                        "client not configured"
+                        if not self.deepseek.enabled()
+                        else "temporarily unavailable"
+                    )
                 )
                 LOGGER.info("DeepSeek controller unavailable for %s: %s", sid, reason)
                 state.controller_notice_logged = True
@@ -273,6 +302,20 @@ class LangGraphMini:
         decision: Optional[ControllerDecision] = None
         try:
             decision = self.deepseek.plan_turn(dialogue_payload, current_progress)
+        except DeepSeekTemporarilyUnavailableError as exc:
+            LOGGER.debug("DeepSeek controller temporarily unavailable for %s: %s", sid, exc)
+            state.controller_notice_logged = True
+            state.controller_unusable_turn = state.last_utt_index
+            self._persist_state(state)
+            return self._fallback_flow(
+                sid=sid,
+                state=state,
+                item_id=item_id,
+                scoring_segments=scoring_segments,
+                dialogue=dialogue_payload,
+                transcripts=transcripts,
+                user_text=user_text,
+            )
         except Exception as exc:  # pragma: no cover - runtime guard
             log_method = LOGGER.warning
             if state.controller_notice_logged:
@@ -292,17 +335,30 @@ class LangGraphMini:
             )
 
         if decision and decision.hamd_partial:
-            analysis_payload = decision.hamd_partial.model_dump()
-            state.analysis = analysis_payload
+            partial_payload = decision.hamd_partial.model_dump()
             try:
-                self.repo.merge_scores(sid, analysis_payload)
+                self.repo.merge_scores(sid, partial_payload)
             except Exception:  # pragma: no cover - runtime guard
                 LOGGER.exception("Failed to merge partial HAMD scores for %s", sid)
-            items_payload = analysis_payload.get("items")
-            if isinstance(items_payload, list):
-                state.scores_acc = items_payload
+            items_payload = partial_payload.get("items") or []
+            normalized_items = [
+                entry
+                for entry in (
+                    self._normalize_score_entry(item) for item in items_payload
+                )
+                if entry
+            ]
+            if normalized_items:
+                self._merge_scores(state, normalized_items)
+            total_payload = partial_payload.get("total_score") or {}
+            total_value = self._extract_total_score(total_payload)
+            if total_value is not None:
+                state.opinion = self._opinion_from_total(total_value)
+
+        if state.scores_acc:
+            state.analysis = self._analysis_from_scores(state)
         else:
-            analysis_payload = None
+            state.analysis = None
 
         if not decision:
             state.controller_unusable_turn = state.last_utt_index
@@ -316,9 +372,6 @@ class LangGraphMini:
                 transcripts=transcripts,
                 user_text=user_text,
             )
-
-        if analysis_payload:
-            state.analysis = analysis_payload
 
         if state.controller_unusable_turn is not None:
             state.controller_unusable_turn = None
@@ -336,7 +389,13 @@ class LangGraphMini:
             LOGGER.exception("Failed to load last clarify target for %s", sid)
             last_clarify = None
 
-        if decision.action == "clarify" and last_clarify and (user_text or prepared_segments):
+        decision_action = decision.action
+
+        if (
+            decision.action == "clarify"
+            and last_clarify
+            and (user_text or prepared_segments)
+        ):
             LOGGER.debug("Clarify override triggered for %s after user response", sid)
             try:
                 self.repo.clear_last_clarify_need(sid)
@@ -348,9 +407,6 @@ class LangGraphMini:
                 next_utt = COMPLETION_TEXT
             else:
                 decision_action = "ask"
-                next_utt = pick_primary(forced_target)
-        else:
-            decision_action = decision.action
 
         if decision_action == "clarify":
             if decision.clarify_target:
@@ -362,6 +418,21 @@ class LangGraphMini:
                     )
                 except Exception:  # pragma: no cover - runtime guard
                     LOGGER.exception("Failed to persist clarify target for %s", sid)
+            target_item_id = (
+                decision.clarify_target.item_id
+                if decision.clarify_target
+                else last_clarify.get("item_id")
+                if isinstance(last_clarify, dict)
+                else item_id
+            )
+            clarify_gap = (
+                decision.clarify_target.clarify_need
+                if decision.clarify_target and decision.clarify_target.clarify_need
+                else last_clarify.get("need")
+                if isinstance(last_clarify, dict)
+                else ""
+            )
+            next_utt = pick_clarify(target_item_id, clarify_gap)
             state.clarify += 1
             self._append_turn(
                 sid,
@@ -380,15 +451,61 @@ class LangGraphMini:
             )
 
         if decision_action == "ask":
-            target_item = forced_target or decision.current_item_id
+            target_item = forced_target
             if target_item in (None, 0):
-                target_item = get_next_item(item_id)
-            self._advance_to(sid, target_item or item_id, state)
-            state.clarify = 0
+                target_item = decision.current_item_id or item_id
+            if target_item in (None, 0):
+                target_item = item_id
+            # 强制与量表顺序对齐：若控制器仍指向当前或更早条目，则推进到下一条
             try:
-                self.repo.clear_last_clarify_need(sid)
-            except Exception:  # pragma: no cover - runtime guard
-                LOGGER.exception("Failed to clear clarify target for %s", sid)
+                target_int = int(target_item)
+            except (TypeError, ValueError):
+                target_int = item_id
+            if target_int <= item_id:
+                target_item = get_next_item(item_id)
+            if target_item in (None, -1):
+                decision_action = "finish"
+                next_utt = COMPLETION_TEXT
+            else:
+                next_utt = pick_primary(target_item)
+
+        if decision_action == "ask":
+            # 末条护栏：已在最后一条且没有待澄清，直接完成
+            if item_id == TOTAL_ITEMS:
+                try:
+                    last_clarify = self.repo.get_last_clarify_need(sid)
+                except Exception:  # pragma: no cover
+                    last_clarify = None
+                no_pending_clarify = not last_clarify
+                if no_pending_clarify and (target_item in (None, 0, TOTAL_ITEMS)):
+                    state.completed = True
+                    state.index = TOTAL_ITEMS
+                    self._persist_state(state)
+                    try:
+                        self.repo.mark_finished(sid)
+                    except Exception:  # pragma: no cover - runtime guard
+                        LOGGER.exception("Failed to mark session %s finished", sid)
+                    try:
+                        self.repo.clear_last_clarify_need(sid)
+                    except Exception:  # pragma: no cover - runtime guard
+                        LOGGER.exception("Failed to clear clarify target for %s", sid)
+                    self._append_turn(
+                        sid,
+                        state,
+                        role="assistant",
+                        turn_type="ask",
+                        text=COMPLETION_TEXT,
+                    )
+                    return self._make_response(
+                        sid,
+                        state,
+                        COMPLETION_TEXT,
+                        turn_type="complete",
+                        extra={"analysis": state.analysis} if state.analysis else None,
+                        record=False,
+                    )
+
+            self._advance_to(sid, target_item or item_id, state)
             self._append_turn(
                 sid,
                 state,
@@ -463,10 +580,124 @@ class LangGraphMini:
         }
         if previews:
             payload["segments_previews"] = previews
-        payload.setdefault("risk", None)
-        payload.setdefault("analysis", state.analysis)
+        payload["risk"] = payload.get("risk", None)
+        # 优先使用 extra.analysis，其次 state.analysis
+        if extra and "analysis" in extra:
+            payload["analysis"] = copy.deepcopy(extra["analysis"])
+        else:
+            payload["analysis"] = copy.deepcopy(state.analysis) if state.analysis else None
         if extra:
-            payload.update(extra)
+            for key, value in extra.items():
+                if key == "analysis":
+                    continue
+                payload[key] = value
+        return payload
+
+    def _maybe_handle_report_request(
+        self, sid: str, state: SessionState, user_text: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        if not user_text:
+            return None
+
+        normalized = user_text.strip()
+        if not normalized:
+            return None
+
+        lowered = normalized.lower()
+        matched = any(
+            pattern.search(normalized) or pattern.search(lowered)
+            for pattern in REPORT_REQUEST_PATTERNS
+        )
+        if not matched:
+            return None
+
+        self._persist_state(state)
+
+        score_payload = self._prepare_report_scores(sid, state)
+        question = pick_primary(self._current_item_id(state))
+
+        if not score_payload:
+            message = f"当前暂无足够信息生成报告，我们先继续评估：{question}"
+            return self._make_response(
+                sid,
+                state,
+                message,
+                turn_type="ask",
+                extra={"report_generated": False},
+            )
+
+        try:
+            report_result = build_pdf(sid, score_payload)
+        except Exception as exc:  # pragma: no cover - runtime guard
+            LOGGER.exception("Failed to build report for %s: %s", sid, exc)
+            message = f"生成报告时遇到问题，我们继续当前评估：{question}"
+            return self._make_response(
+                sid,
+                state,
+                message,
+                turn_type="ask",
+                extra={"report_generated": False},
+            )
+
+        report_url = (
+            report_result.get("report_url")
+            if isinstance(report_result, dict)
+            else None
+        )
+        if not report_url:
+            message = f"暂时无法提供下载链接，我们先继续评估：{question}"
+            return self._make_response(
+                sid,
+                state,
+                message,
+                turn_type="ask",
+                extra={"report_generated": False},
+            )
+
+        message = f"已为您生成评估报告，可通过此链接下载：{report_url}。我们继续：{question}"
+        extra = {"report_generated": True, "report_url": report_url}
+        if state.analysis:
+            extra["analysis"] = state.analysis
+        return self._make_response(
+            sid,
+            state,
+            message,
+            turn_type="ask",
+            extra=extra,
+        )
+
+    def _prepare_report_scores(
+        self, sid: str, state: SessionState
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            stored_scores = self.repo.load_scores(sid)
+        except Exception:  # pragma: no cover - runtime guard
+            LOGGER.exception("Failed to load stored scores for %s", sid)
+            stored_scores = None
+
+        payload: Dict[str, Any] = {}
+        if isinstance(stored_scores, dict):
+            payload.update(copy.deepcopy(stored_scores))
+        elif isinstance(stored_scores, list):
+            payload["items"] = copy.deepcopy(stored_scores)
+
+        if state.scores_acc:
+            payload.setdefault("items", copy.deepcopy(state.scores_acc))
+
+        if state.analysis and isinstance(state.analysis, dict):
+            total_block = state.analysis.get("total_score")
+            if total_block:
+                payload.setdefault("total_score", copy.deepcopy(total_block))
+
+        if state.opinion:
+            if isinstance(payload.get("opinion"), dict):
+                payload["opinion"].setdefault("summary", state.opinion)
+            else:
+                payload["opinion"] = {"summary": state.opinion}
+
+        if not payload.get("items") and not payload.get("per_item_scores"):
+            return None
+
         return payload
 
     def _emit_risk_event(self, sid: str, payload: Dict[str, Any]) -> None:
@@ -567,6 +798,11 @@ class LangGraphMini:
             state = self._load_state(sid)
         state.index = target
         state.clarify = 0
+        # 统一清理上一轮的 clarify 记录，避免遗留阻塞推进
+        try:
+            self.repo.clear_last_clarify_need(state.sid)
+        except Exception:  # pragma: no cover - runtime guard
+            LOGGER.exception("Failed to clear clarify target for %s", state.sid)
         self._persist_state(state)
         return state
 
@@ -649,11 +885,50 @@ class LangGraphMini:
         self,
         state: SessionState,
         transcripts: List[Dict[str, Any]],
+        dialogue: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[Dict[str, Any]]:
         if not transcripts:
             return None
 
+        semantic_result = self._semantic_score_current_item(
+            state, transcripts, dialogue
+        )
+        if semantic_result:
+            return semantic_result
+
+        return None
+
+    def _semantic_score_current_item(
+        self,
+        state: SessionState,
+        transcripts: List[Dict[str, Any]],
+        dialogue: Optional[List[Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        if not self.deepseek.usable():
+            return None
+
+        dialogue_payload = list(dialogue) if dialogue else self._build_dialogue_payload(
+            state.sid
+        )
+        if not dialogue_payload:
+            return None
+
+        try:
+            result = self.deepseek.analyze(dialogue_payload, get_prompt_hamd17())
+        except DeepSeekTemporarilyUnavailableError as exc:
+            LOGGER.debug("DeepSeek semantic scoring skipped for %s: %s", state.sid, exc)
+            return None
+        except Exception as exc:  # pragma: no cover - runtime guard
+            LOGGER.debug(
+                "DeepSeek semantic scoring skipped for %s: %s", state.sid, exc
+            )
+            return None
+
         item_id = self._current_item_id(state)
+        target = next((item for item in result.items if item.item_id == item_id), None)
+        if target is None:
+            return None
+
         question = pick_primary(item_id)
         latest_segment = next(
             (
@@ -663,17 +938,24 @@ class LangGraphMini:
             ),
             transcripts[-1],
         )
-        text = str(latest_segment.get("text", ""))
-        score = self._rule_based_score(text, item_id)
-        evidence_refs = [latest_segment.get("utt_id", "")]
+        evidence_refs = [ref for ref in target.evidence_refs if ref]
+        if not evidence_refs and latest_segment:
+            evidence_id = latest_segment.get("utt_id", "")
+            if evidence_id:
+                evidence_refs = [evidence_id]
 
-        per_item_score = {
+        per_item_score: Dict[str, Any] = {
             "item_id": f"H{item_id:02d}",
             "name": question,
             "question": question,
-            "score": score,
+            "score": min(int(target.score), MAX_SCORE.get(item_id, 4)),
             "max_score": MAX_SCORE.get(item_id, 4),
             "evidence_refs": evidence_refs,
+            "score_type": target.score_type,
+            "score_reason": target.score_reason,
+            "dialogue_evidence": target.dialogue_evidence,
+            "symptom_summary": target.symptom_summary,
+            "clarify_need": target.clarify_need,
         }
 
         opinion = self._generate_opinion(state.scores_acc, per_item_score)
@@ -683,29 +965,110 @@ class LangGraphMini:
             "opinion": opinion,
         }
 
-    def _rule_based_score(self, text: str, item_id: int) -> int:
-        normalized = text.strip()
-        lowered = normalized.lower()
+    @staticmethod
+    def _extract_total_score(payload: Dict[str, Any]) -> Optional[int]:
+        for key in ("corrected_total", "pre_correction_total", "total"):
+            value = payload.get(key)
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    def _standardize_score_entry(
+        self, item_id: int, payload: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        base = dict(payload or {})
+        normalized = copy.deepcopy(base)
+        normalized["item_id"] = f"H{item_id:02d}"
+        normalized["name"] = normalized.get("name") or self.ITEM_NAMES.get(
+            item_id, f"条目{item_id}"
+        )
+        normalized["question"] = normalized.get("question") or pick_primary(item_id)
+        try:
+            score_value = int(normalized.get("score", 0))
+        except (TypeError, ValueError):
+            score_value = 0
         max_score = MAX_SCORE.get(item_id, 4)
-        if not normalized:
-            return 0
-        if any(keyword in normalized for keyword in ["没有", "不", "很少", "没"]):
-            return 0
-        if any(keyword in normalized for keyword in ["严重", "完全", "一直", "难以"]):
-            return min(4, max_score)
-        if any(keyword in lowered for keyword in ["经常", "很多", "每天", "总是"]):
-            return min(3, max_score)
-        if any(keyword in lowered for keyword in ["有时", "偶尔", "有点", "几天"]):
-            return min(2, max_score)
-        return 1 if max_score >= 1 else 0
+        normalized["score"] = max(0, min(score_value, max_score))
+        normalized["max_score"] = max_score
+        normalized["evidence_refs"] = list(normalized.get("evidence_refs") or [])
+        normalized["dialogue_evidence"] = normalized.get("dialogue_evidence") or "直接引用"
+        normalized["symptom_summary"] = normalized.get("symptom_summary") or ""
+        normalized["score_type"] = normalized.get("score_type") or "类型1"
+        normalized["score_reason"] = normalized.get("score_reason") or ""
+        clarify_need = normalized.get("clarify_need")
+        normalized["clarify_need"] = clarify_need if clarify_need not in {"", None} else None
+        return normalized
+
+    def _normalize_score_entry(
+        self, payload: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        if not isinstance(payload, dict):
+            return None
+        raw_id = payload.get("item_id")
+        item_id: Optional[int]
+        if isinstance(raw_id, int):
+            item_id = raw_id
+        elif isinstance(raw_id, str):
+            stripped = raw_id.strip().upper()
+            if stripped.startswith("H"):
+                stripped = stripped[1:]
+            if not stripped:
+                return None
+            try:
+                item_id = int(stripped)
+            except ValueError:
+                return None
+        else:
+            try:
+                item_id = int(raw_id)
+            except (TypeError, ValueError):
+                return None
+        if not (1 <= item_id <= TOTAL_ITEMS):
+            return None
+        return self._standardize_score_entry(item_id, payload)
 
     def _merge_scores(self, state: SessionState, new_scores: List[Dict[str, Any]]) -> None:
-        scores_by_id = {score["item_id"]: score for score in state.scores_acc}
+        scores_by_id: Dict[str, Dict[str, Any]] = {}
+        for existing in state.scores_acc:
+            normalized = self._normalize_score_entry(existing)
+            if not normalized:
+                continue
+            scores_by_id[normalized["item_id"]] = normalized
+
+        def score_value(entry: Dict[str, Any]) -> int:
+            try:
+                return int(entry.get("score", 0))
+            except (TypeError, ValueError):
+                return 0
+
         for score in new_scores:
-            item_id = score["item_id"]
-            existing = scores_by_id.get(item_id)
-            if existing is None or score.get("score", 0) >= existing.get("score", 0):
-                scores_by_id[item_id] = score
+            normalized = self._normalize_score_entry(score)
+            if not normalized:
+                continue
+            key = normalized["item_id"]
+            current = scores_by_id.get(key)
+            if current is None:
+                scores_by_id[key] = normalized
+                continue
+            existing_value = score_value(current)
+            candidate_value = score_value(normalized)
+            if candidate_value > existing_value:
+                scores_by_id[key] = normalized
+            elif candidate_value == existing_value:
+                current_refs = len(current.get("evidence_refs") or [])
+                candidate_refs = len(normalized.get("evidence_refs") or [])
+                if candidate_refs > current_refs:
+                    scores_by_id[key] = normalized
+                elif candidate_refs == current_refs:
+                    current_summary = current.get("symptom_summary") or ""
+                    candidate_summary = normalized.get("symptom_summary") or ""
+                    if not current_summary and candidate_summary:
+                        scores_by_id[key] = normalized
+
         ordered: List[Dict[str, Any]] = []
         for idx in range(1, TOTAL_ITEMS + 1):
             key = f"H{idx:02d}"
@@ -756,6 +1119,65 @@ class LangGraphMini:
         response.update(payload)
         return response
 
+    def _analysis_from_scores(self, state: SessionState) -> Dict[str, Any]:
+        """根据已有的 scores_acc 生成一个轻量级 analysis 快照。"""
+        normalized_scores: List[Dict[str, Any]] = []
+        for entry in state.scores_acc:
+            normalized = self._normalize_score_entry(entry)
+            if normalized:
+                normalized_scores.append(normalized)
+        state.scores_acc = normalized_scores
+
+        scores_map = {score["item_id"]: score for score in normalized_scores}
+        seq_list: List[str] = []
+        items: List[Dict[str, Any]] = []
+        total = 0
+        type4_count = 0
+        for idx in range(1, TOTAL_ITEMS + 1):
+            key = f"H{idx:02d}"
+            score_entry = scores_map.get(key)
+            if score_entry:
+                try:
+                    score_value = int(score_entry.get("score", 0))
+                except (TypeError, ValueError):
+                    score_value = 0
+            else:
+                score_value = 0
+            seq_list.append(str(score_value))
+            total += score_value
+            if not score_entry:
+                continue
+            if score_entry.get("score_type") == "类型4":
+                type4_count += 1
+            items.append(
+                {
+                    "item_id": idx,
+                    "symptom_summary": score_entry.get("symptom_summary")
+                    or self.ITEM_NAMES.get(idx, f"条目{idx}"),
+                    "dialogue_evidence": score_entry.get("dialogue_evidence", "直接引用"),
+                    "evidence_refs": score_entry.get("evidence_refs", []),
+                    "score": score_value,
+                    "score_type": score_entry.get("score_type", "类型1"),
+                    "score_reason": score_entry.get("score_reason", ""),
+                    "clarify_need": score_entry.get("clarify_need"),
+                }
+            )
+
+        avg = total / type4_count if type4_count else 0
+        correction_basis = (
+            f"类型4条目数量N4={type4_count}，平均分X={avg:.2f}，修正总分=A+X×N4={total}"
+        )
+
+        return {
+            "items": items,
+            "total_score": {
+                "得分序列": ",".join(seq_list),
+                "pre_correction_total": total,
+                "corrected_total": total,
+                "correction_basis": correction_basis,
+            },
+        }
+
     def _complete_payload(self, state: SessionState, message: str) -> Dict[str, Any]:
         return self._make_response(
             state.sid,
@@ -763,9 +1185,6 @@ class LangGraphMini:
             message,
             turn_type="complete",
         )
-
-    def _detect_gaps(self, state: SessionState, item_id: int) -> List[str]:
-        return detect_information_gaps(state.last_text, item_id=item_id)
 
     def _fallback_flow(
         self,
@@ -782,21 +1201,28 @@ class LangGraphMini:
         extra_payload: Dict[str, Any] = {}
 
         if analysis_result:
-            analysis_dict = analysis_result.model_dump()
-            state.analysis = analysis_dict
-            extra_payload["analysis"] = analysis_dict
             self._store_analysis_scores(sid, state, analysis_result)
         else:
-            state.analysis = None
-            score_result = self._score_current_item(state, scoring_segments)
+            score_result = self._score_current_item(state, scoring_segments, dialogue)
             if score_result:
                 self._merge_scores(state, score_result["per_item_scores"])
                 state.opinion = score_result.get("opinion") or state.opinion
+                state.analysis = self._analysis_from_scores(state)
 
-        reverse_gap_labels = {label: key for key, label in GAP_LABELS.items()}
-        fallback_gaps = self._detect_gaps(state, item_id)
+        if state.analysis is not None:
+            extra_payload["analysis"] = copy.deepcopy(state.analysis)
+        else:
+            extra_payload["analysis"] = None
 
-        stored_gap_key: Optional[str] = None
+        active_clarify_need: Optional[str] = None
+        if analysis_result:
+            target_item = next(
+                (item for item in analysis_result.items if item.item_id == item_id),
+                None,
+            )
+            if target_item:
+                active_clarify_need = target_item.clarify_need or None
+
         try:
             last_clarify = self.repo.get_last_clarify_need(sid)
         except Exception:  # pragma: no cover - runtime guard
@@ -805,41 +1231,27 @@ class LangGraphMini:
 
         if last_clarify and last_clarify.get("item_id") == item_id:
             stored_need = last_clarify.get("need")
-            if isinstance(stored_need, str):
-                stored_gap_key = reverse_gap_labels.get(stored_need, stored_need)
-            if stored_gap_key and stored_gap_key not in fallback_gaps:
+            if not active_clarify_need or stored_need != active_clarify_need:
                 try:
                     self.repo.clear_last_clarify_need(sid)
                 except Exception:  # pragma: no cover - runtime guard
                     LOGGER.exception("Failed to clear clarify target for %s", sid)
-                stored_gap_key = None
 
-        if not analysis_result and user_text and state.clarify < 2:
-            if self._is_vague(user_text) or fallback_gaps:
-                state.clarify += 1
-                clarify_key = fallback_gaps[0] if fallback_gaps else "severity"
-                clarify_label = GAP_LABELS.get(clarify_key, clarify_key)
-                try:
-                    self.repo.set_last_clarify_need(sid, item_id, clarify_label)
-                except Exception:  # pragma: no cover - runtime guard
-                    LOGGER.exception("Failed to persist clarify target for %s", sid)
-                clarify_prompt = pick_clarify(item_id, clarify_key)
-                self._persist_state(state)
-                return self._make_response(
-                    sid,
-                    state,
-                    clarify_prompt,
-                    turn_type="clarify",
-                    extra=extra_payload,
-                )
-
-        clarify_question = None
+        clarify_payload: Optional[Tuple[str, int, str]] = None
         if analysis_result and user_text and state.clarify < 2:
-            clarify_question = self._clarify_from_analysis(
+            clarify_payload = self._clarify_from_analysis(
                 state, analysis_result, dialogue
             )
 
-        if clarify_question:
+        if clarify_payload:
+            clarify_question, clarify_item_id, clarify_need = clarify_payload
+            if clarify_need:
+                try:
+                    self.repo.set_last_clarify_need(
+                        sid, clarify_item_id, clarify_need
+                    )
+                except Exception:  # pragma: no cover - runtime guard
+                    LOGGER.exception("Failed to persist clarify target for %s", sid)
             state.clarify += 1
             self._persist_state(state)
             return self._make_response(
@@ -854,14 +1266,7 @@ class LangGraphMini:
 
         next_item = get_next_item(item_id)
         if next_item != -1:
-            state.index = next_item
-            self._persist_state(state)
-            try:
-                self.repo.clear_last_clarify_need(sid)
-            except Exception:  # pragma: no cover - runtime guard
-                LOGGER.exception(
-                    "Failed to clear clarify target after advancing for %s", sid
-                )
+            self._advance_to(sid, next_item, state)
             next_question = pick_primary(next_item)
             return self._make_response(
                 sid,
@@ -978,17 +1383,6 @@ class LangGraphMini:
             LOGGER.warning("Invalid value for %s: %s; using default %s", name, raw, default)
             return default
 
-    @staticmethod
-    def _is_vague(text: str) -> bool:
-        if not text:
-            return False
-        normalized = re.sub(r"[\s\W]+", "", text, flags=re.UNICODE).lower()
-        for phrase in VAGUE_PHRASES:
-            phrase_norm = re.sub(r"[\s\W]+", "", phrase, flags=re.UNICODE).lower()
-            if phrase_norm and phrase_norm in normalized:
-                return True
-        return False
-
     def _generate_opinion(
         self, existing_scores: List[Dict[str, Any]], new_score: Dict[str, Any]
     ) -> str:
@@ -1028,12 +1422,15 @@ class LangGraphMini:
         return dialogue
 
     def _run_deepseek_analysis(self, dialogue: List[Dict[str, Any]]) -> Optional[HAMDResult]:
-        if not dialogue or len(dialogue) < 4:
+        if not dialogue:
             return None
-        if not self.deepseek.enabled():
+        if not self.deepseek.usable():
             return None
         try:
             return self.deepseek.analyze(dialogue, get_prompt_hamd17())
+        except DeepSeekTemporarilyUnavailableError as exc:
+            LOGGER.debug("DeepSeek analysis temporarily unavailable: %s", exc)
+            return None
         except Exception as exc:  # pragma: no cover - runtime guard
             LOGGER.warning("DeepSeek analysis skipped: %s", exc)
             return None
@@ -1041,22 +1438,42 @@ class LangGraphMini:
     def _store_analysis_scores(
         self, sid: str, state: SessionState, result: HAMDResult
     ) -> None:
-        items = []
+        normalized_items: List[Dict[str, Any]] = []
         for item in result.items:
-            items.append(
+            normalized = self._normalize_score_entry(
                 {
-                    "item_id": f"H{item.item_id:02d}",
-                    "name": self.ITEM_NAMES.get(item.item_id, f"条目{item.item_id}"),
-                    "question": pick_primary(item.item_id),
+                    "item_id": item.item_id,
                     "score": item.score,
                     "max_score": MAX_SCORE.get(item.item_id, 4),
                     "evidence_refs": item.evidence_refs,
                     "score_type": item.score_type,
                     "score_reason": item.score_reason,
+                    "dialogue_evidence": getattr(item, "dialogue_evidence", None),
+                    "symptom_summary": getattr(item, "symptom_summary", None),
                     "clarify_need": item.clarify_need,
                 }
             )
-        state.scores_acc = items
+            if normalized:
+                normalized_items.append(normalized)
+
+        if normalized_items:
+            self._merge_scores(state, normalized_items)
+
+        analysis_snapshot = (
+            self._analysis_from_scores(state) if state.scores_acc else {}
+        )
+        summary = getattr(result, "summary", None)
+        if summary:
+            analysis_snapshot = dict(analysis_snapshot or {})
+            analysis_snapshot["summary"] = summary
+        state.analysis = analysis_snapshot or None
+
+        if state.analysis:
+            total_payload = state.analysis.get("total_score") or {}
+            total_value = self._extract_total_score(total_payload)
+            if total_value is not None:
+                state.opinion = state.opinion or self._opinion_from_total(total_value)
+
         try:
             repository.save_scores(sid, result.model_dump())
         except Exception:  # pragma: no cover - runtime guard
@@ -1068,7 +1485,7 @@ class LangGraphMini:
         state: SessionState,
         result: HAMDResult,
         dialogue: List[Dict[str, Any]],
-    ) -> Optional[str]:
+    ) -> Optional[Tuple[str, int, str]]:
         current_item = self._current_item_id(state)
         target = next(
             (
@@ -1079,27 +1496,13 @@ class LangGraphMini:
             None,
         )
         if target is None:
-            target = next(
-                (item for item in result.items if item.score_type == "类型4" and item.clarify_need),
-                None,
-            )
-        if target is None:
             return None
         clarify_need = target.clarify_need or ""
         evidence_text = "；".join(
             [entry.get("text", "") for entry in dialogue if entry.get("role") == "user"][-2:]
         )
-        question = None
-        if self.deepseek.enabled():
-            question = self.deepseek.gen_clarify_question(
-                target.item_id,
-                self.ITEM_NAMES.get(target.item_id, f"条目{target.item_id}"),
-                clarify_need,
-                evidence_text,
-            )
-        if not question:
-            question = self.CLARIFY_FALLBACKS.get(clarify_need, "能再具体说说这个情况吗？")
-        return question
+        question = pick_clarify(target.item_id, clarify_need)
+        return question, target.item_id, clarify_need
 
 
 orchestrator = LangGraphMini()

--- a/services/tts/tts_adapter.py
+++ b/services/tts/tts_adapter.py
@@ -1,40 +1,189 @@
+import importlib
+import importlib.util
 import logging
 import os
 import time
 import uuid
 import wave
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from packages.common.config import settings
 
 LOGGER = logging.getLogger(__name__)
 SR = 16000
 
 
+def _discover_dashscope() -> Tuple[Optional[Any], Optional[type]]:
+    """Return the dashscope module and SpeechSynthesizer class if available."""
+
+    if importlib.util.find_spec("dashscope") is None:
+        return None, None
+
+    dashscope_module = importlib.import_module("dashscope")
+    if importlib.util.find_spec("dashscope.audio.tts_v2") is None:
+        return dashscope_module, None
+
+    tts_module = importlib.import_module("dashscope.audio.tts_v2")
+    synthesizer_cls = getattr(tts_module, "SpeechSynthesizer", None)
+    return dashscope_module, synthesizer_cls
+
+
+_DASHSCOPE_MODULE, _SPEECH_SYNTHESIZER_CLS = _discover_dashscope()
+
+
 class TTSAdapter:
-    def __init__(self, out_dir: str = "/tmp/da_tts") -> None:
+    def __init__(
+        self,
+        out_dir: str = "/tmp/da_tts",
+        *,
+        synthesizer_factory: Optional[
+            Callable[[str, str, Optional[str]], Any]
+        ] = None,
+    ) -> None:
         self.out_dir = Path(out_dir)
         self.out_dir.mkdir(parents=True, exist_ok=True)
-        # 预留未来接入 CoSyVoice 的 Key
-        self.api_key = os.getenv("DASHSCOPE_API_KEY")
+        self.api_key = (
+            getattr(settings, "dashscope_api_key", None)
+            or os.getenv("DASHSCOPE_API_KEY")
+        )
+        self.model = getattr(settings, "dashscope_tts_model", "cosyvoice-v2")
+        self.voice = getattr(settings, "dashscope_tts_voice", "longxiaochun_v2")
+        self.audio_format = (
+            getattr(settings, "dashscope_tts_format", "wav") or "wav"
+        ).lower()
+        self.file_extension = self._normalize_extension(self.audio_format)
+        self._synthesizer_cache: Dict[str, Any] = {}
+
+        if synthesizer_factory is not None:
+            self._synthesizer_factory = synthesizer_factory
+        elif _SPEECH_SYNTHESIZER_CLS and self.api_key:
+            if _DASHSCOPE_MODULE is not None:
+                _DASHSCOPE_MODULE.api_key = self.api_key
+
+            def _factory(model: str, voice: str, audio_format: Optional[str]) -> Any:
+                kwargs: Dict[str, Any] = {"model": model, "voice": voice}
+                return _SPEECH_SYNTHESIZER_CLS(**kwargs)  # type: ignore[misc]
+
+            self._synthesizer_factory = _factory
+        else:
+            self._synthesizer_factory = None
+
+    def _normalize_extension(self, fmt: Optional[str]) -> str:
+        if not fmt:
+            return "wav"
+        fmt_lower = fmt.lower().lstrip(".")
+        if fmt_lower in {"wav", "wave"}:
+            return "wav"
+        if fmt_lower in {"mp3", "m4a", "aac"}:
+            return fmt_lower
+        return fmt_lower
+
+    def _cache_key(self, model: str, voice: str) -> str:
+        return f"{model}:{voice}"
+
+    def _get_synthesizer(self, model: str, voice: str) -> Optional[Any]:
+        if self._synthesizer_factory is None:
+            return None
+
+        cache_key = self._cache_key(model, voice)
+        if cache_key in self._synthesizer_cache:
+            return self._synthesizer_cache[cache_key]
+
+        try:
+            synthesizer = self._synthesizer_factory(model, voice, self.audio_format)
+        except Exception:  # pragma: no cover - defensive guard
+            LOGGER.exception("Failed to initialise DashScope synthesizer")
+            return None
+
+        self._synthesizer_cache[cache_key] = synthesizer
+        return synthesizer
 
     def _write_silence_wav(self, path: Path, seconds: float = 1.0) -> None:
         frames = int(SR * seconds)
-        with wave.open(str(path), "wb") as wav:
-            wav.setnchannels(1)
-            wav.setsampwidth(2)
-            wav.setframerate(SR)
-            wav.writeframes(b"\x00\x00" * frames)
+        with wave.open(str(path), "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(SR)
+            wav_file.writeframes(b"\x00\x00" * frames)
+
+    def _call_synthesizer(
+        self, synthesizer: Any, text: str, *, audio_format: Optional[str]
+    ) -> Tuple[Optional[bytes], Optional[str], Optional[float]]:
+        call_kwargs: Dict[str, Any] = {}
+        if audio_format:
+            call_kwargs["format"] = audio_format
+
+        try:
+            if call_kwargs:
+                audio = synthesizer.call(text, **call_kwargs)
+            else:
+                audio = synthesizer.call(text)
+        except TypeError:
+            audio = synthesizer.call(text)
+
+        request_id = None
+        delay_ms = None
+        if hasattr(synthesizer, "get_last_request_id"):
+            try:
+                request_id = synthesizer.get_last_request_id()
+            except Exception:  # pragma: no cover - defensive log guard
+                request_id = None
+        if hasattr(synthesizer, "get_first_package_delay"):
+            try:
+                delay_ms = synthesizer.get_first_package_delay()
+            except Exception:  # pragma: no cover - defensive log guard
+                delay_ms = None
+
+        return audio, request_id, delay_ms
 
     def synthesize(self, sid: str, text: str, voice: Optional[str] = None) -> str:
-        timestamp = int(time.time() * 1000)
-        filename = f"{sid}-{timestamp}-{uuid.uuid4().hex}.wav"
         session_dir = self.out_dir / sid
         session_dir.mkdir(parents=True, exist_ok=True)
+
+        if text:
+            text = text.strip()
+
+        target_voice = voice or self.voice or ""
+        cache_key = self._cache_key(self.model, target_voice)
+
+        if text and self._synthesizer_factory is not None:
+            try:
+                synthesizer = self._get_synthesizer(self.model, target_voice)
+                if synthesizer is not None:
+                    audio_bytes, request_id, delay_ms = self._call_synthesizer(
+                        synthesizer, text, audio_format=self.audio_format
+                    )
+                    if audio_bytes:
+                        timestamp = int(time.time() * 1000)
+                        filename = (
+                            f"{sid}-{timestamp}-{uuid.uuid4().hex}.{self.file_extension}"
+                        )
+                        target = session_dir / filename
+                        target.write_bytes(audio_bytes)
+                        LOGGER.info(
+                            "[TTS:dashscope] synthesized audio",
+                            extra={
+                                "sid": sid,
+                                "path": str(target),
+                                "voice": target_voice,
+                                "text": text[:80] if text else "",
+                                "request_id": request_id,
+                                "first_package_delay_ms": delay_ms,
+                            },
+                        )
+                        return f"file://{target.resolve()}"
+            except Exception:
+                LOGGER.exception("DashScope TTS synthesis failed; falling back to stub")
+                self._synthesizer_cache.pop(cache_key, None)
+
+        timestamp = int(time.time() * 1000)
+        filename = f"{sid}-{timestamp}-{uuid.uuid4().hex}.wav"
         target = session_dir / filename
         self._write_silence_wav(target, seconds=1.0)
         LOGGER.info(
             "[TTS:stub] synthesized placeholder wav",
-            extra={"sid": sid, "path": str(target), "voice": voice, "text": text[:80]},
+            extra={"sid": sid, "path": str(target), "voice": voice, "text": text[:80] if text else ""},
         )
         return f"file://{target.resolve()}"
 

--- a/tests/test_deepseek_client.py
+++ b/tests/test_deepseek_client.py
@@ -19,9 +19,14 @@ class _RequestError(Exception):
     pass
 
 
+class _ReadTimeout(_RequestError):
+    pass
+
+
 httpx_stub.Client = object
 httpx_stub.HTTPStatusError = _HTTPStatusError
 httpx_stub.RequestError = _RequestError
+httpx_stub.ReadTimeout = _ReadTimeout
 sys.modules.setdefault("httpx", httpx_stub)
 
 config_stub = types.ModuleType("packages.common.config")
@@ -30,6 +35,9 @@ config_stub = types.ModuleType("packages.common.config")
 class _Settings:
     deepseek_api_base: str | None = None
     deepseek_api_key: str | None = None
+    deepseek_chat_timeout: float = 90.0
+    deepseek_clarify_timeout: float = 60.0
+    deepseek_controller_timeout: float = 90.0
 
 
 config_stub.settings = _Settings()
@@ -91,7 +99,10 @@ sys.modules.setdefault("tenacity", tenacity_stub)
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from services.llm.json_client import DeepSeekJSONClient
+from services.llm.json_client import (
+    DeepSeekJSONClient,
+    DeepSeekTemporarilyUnavailableError,
+)
 
 
 class _DummyResponse:
@@ -139,3 +150,16 @@ def test_post_chat_normalizes_deepseek_base(monkeypatch: pytest.MonkeyPatch, bas
 
     assert result == "{}"
     assert captured == ["https://api.deepseek.com/v1/chat/completions"]
+
+
+def test_post_chat_respects_circuit_breaker(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _client_factory(*args, **kwargs):  # pragma: no cover - guard
+        raise AssertionError("httpx.Client should not be constructed when circuit is open")
+
+    monkeypatch.setattr("services.llm.json_client.httpx.Client", _client_factory)
+
+    client = DeepSeekJSONClient(base="https://api.deepseek.com/v1", key="test-key", model="dummy")
+    client._trip_circuit(duration=10)
+
+    with pytest.raises(DeepSeekTemporarilyUnavailableError):
+        client._post_chat(messages=[{"role": "user", "content": "hi"}])

--- a/tests/test_orchestrator_clarify.py
+++ b/tests/test_orchestrator_clarify.py
@@ -1,0 +1,277 @@
+import sys
+import types
+from typing import Any, Dict, List, Optional, Tuple
+
+_nls = types.ModuleType("nls")
+setattr(_nls, "enableTrace", lambda *_args, **_kwargs: None)
+setattr(_nls, "setLogFile", lambda *_args, **_kwargs: None)
+sys.modules.setdefault("nls", _nls)
+
+_aliyun = types.ModuleType("aliyunsdkcore")
+_aliyun_client = types.ModuleType("aliyunsdkcore.client")
+setattr(_aliyun_client, "AcsClient", object)
+_aliyun.client = _aliyun_client
+_aliyun_request = types.ModuleType("aliyunsdkcore.request")
+setattr(_aliyun_request, "CommonRequest", object)
+_aliyun.request = _aliyun_request
+sys.modules.setdefault("aliyunsdkcore", _aliyun)
+sys.modules.setdefault("aliyunsdkcore.client", _aliyun_client)
+sys.modules.setdefault("aliyunsdkcore.request", _aliyun_request)
+
+_jinja2 = types.ModuleType("jinja2")
+
+
+class _FakeTemplate:
+    def render(self, **_: Any) -> str:
+        return ""
+
+
+class _FakeEnv:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def from_string(self, _template: str) -> _FakeTemplate:
+        return _FakeTemplate()
+
+
+_jinja2.Environment = lambda *args, **kwargs: _FakeEnv(*args, **kwargs)
+_jinja2.select_autoescape = lambda *args, **kwargs: None
+sys.modules.setdefault("jinja2", _jinja2)
+
+_weasyprint = types.ModuleType("weasyprint")
+
+
+class _FakeHTML:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def write_pdf(self, _path: str) -> None:
+        return None
+
+
+_weasyprint.HTML = lambda *args, **kwargs: _FakeHTML(*args, **kwargs)
+sys.modules.setdefault("weasyprint", _weasyprint)
+
+packages_stub = types.ModuleType("packages")
+common_stub = types.ModuleType("packages.common")
+config_stub = types.ModuleType("packages.common.config")
+
+store_repo_stub = types.ModuleType("services.store.repository")
+
+
+class _RepoStub:
+    def load_session_state(self, sid: str) -> Dict[str, Any]:
+        return {}
+
+    def save_session_state(self, sid: str, payload: Dict[str, Any]) -> None:
+        return None
+
+    def append_transcript(self, sid: str, event: Dict[str, Any]) -> None:
+        return None
+
+    def get_transcripts(self, sid: str) -> List[Dict[str, Any]]:
+        return []
+
+    def clear_last_clarify_need(self, sid: str) -> None:
+        return None
+
+    def get_last_clarify_need(self, sid: str) -> Optional[Dict[str, Any]]:
+        return None
+
+    def set_last_clarify_need(self, sid: str, item_id: int, need: str) -> None:
+        return None
+
+    def merge_scores(self, sid: str, payload: Dict[str, Any]) -> None:
+        return None
+
+    def mark_finished(self, sid: str) -> None:
+        return None
+
+    def push_risk_event_stream(self, sid: str, payload: Dict[str, Any]) -> None:
+        return None
+
+    def push_risk_event(self, sid: str, payload: Dict[str, Any]) -> None:
+        return None
+
+    def append_risk_event(self, sid: str, payload: Dict[str, Any]) -> None:
+        return None
+
+    def save_scores(self, sid: str, payload: Dict[str, Any]) -> None:
+        return None
+
+
+store_repo_stub.repository = _RepoStub()
+sys.modules["services.store.repository"] = store_repo_stub
+
+
+class _Settings:
+    def __init__(self) -> None:
+        self.deepseek_api_base = None
+        self.deepseek_api_key = None
+        self.ENABLE_DS_CONTROLLER = False
+        self.ALIBABA_CLOUD_ACCESS_KEY_ID = ""
+        self.ALIBABA_CLOUD_ACCESS_KEY_SECRET = ""
+        self.TINGWU_REGION = "cn-beijing"
+        self.TINGWU_APPKEY = ""
+        self.ALIBABA_TINGWU_APPKEY = ""
+        self.TINGWU_AK_ID = ""
+        self.TINGWU_AK_SECRET = ""
+        self.TINGWU_BASE = "https://example"
+        self.TINGWU_WS_BASE = "wss://example"
+        self.TINGWU_SAMPLE_RATE = 16000
+        self.TINGWU_FORMAT = "pcm"
+        self.TINGWU_LANG = "cn"
+
+
+config_stub.settings = _Settings()
+packages_stub.common = common_stub
+common_stub.config = config_stub
+
+sys.modules["packages"] = packages_stub
+sys.modules["packages.common"] = common_stub
+sys.modules["packages.common.config"] = config_stub
+
+import pytest
+
+from services.llm.json_client import HAMDItem, HAMDResult, HAMDTotal
+from services.orchestrator.langgraph_min import LangGraphMini, SessionState
+
+
+settings = config_stub.settings
+
+
+class _DummyRepo:
+    def __init__(self) -> None:
+        self.session: Dict[str, Dict[str, Any]] = {}
+        self.last_set: Optional[Tuple[str, int, str]] = None
+
+    def save_session_state(self, sid: str, payload: Dict[str, Any]) -> None:
+        self.session[sid] = dict(payload)
+
+    def append_transcript(self, sid: str, event: Dict[str, Any]) -> None:  # pragma: no cover - not used
+        self.session.setdefault(sid, {})
+
+    def get_transcripts(self, sid: str) -> List[Dict[str, Any]]:
+        return []
+
+    def clear_last_clarify_need(self, sid: str) -> None:  # pragma: no cover - not used
+        return None
+
+    def get_last_clarify_need(self, sid: str) -> Optional[Dict[str, Any]]:
+        return None
+
+    def set_last_clarify_need(self, sid: str, item_id: int, need: str) -> None:  # pragma: no cover - not used
+        self.last_set = (sid, item_id, need)
+
+    def mark_finished(self, sid: str) -> None:  # pragma: no cover - not used
+        return None
+
+    def save_scores(self, sid: str, payload: Dict[str, Any]) -> None:  # pragma: no cover - not used
+        return None
+
+
+class _DummyDeepSeek:
+    def usable(self) -> bool:
+        return False
+
+    def gen_clarify_question(self, *args: Any, **kwargs: Any) -> Optional[str]:  # pragma: no cover - not used
+        return None
+
+
+def _make_result(items: List[HAMDItem]) -> HAMDResult:
+    return HAMDResult(
+        items=items,
+        total_score=HAMDTotal(
+            得分序列="0", pre_correction_total=0, corrected_total=0, correction_basis=""
+        ),
+    )
+
+
+def test_clarify_does_not_jump_to_previous_items() -> None:
+    orchestrator = LangGraphMini.__new__(LangGraphMini)
+    orchestrator.deepseek = _DummyDeepSeek()
+    orchestrator.ITEM_NAMES = {3: "自杀倾向", 15: "疑病倾向"}
+
+    state = SessionState(sid="sid", index=15)
+
+    result = _make_result(
+        [
+            HAMDItem(
+                item_id=3,
+                symptom_summary="信息有限",
+                dialogue_evidence="描述不足",
+                evidence_refs=[],
+                score=0,
+                score_type="类型4",
+                score_reason="缺少信息",
+                clarify_need="频次",
+            ),
+            HAMDItem(
+                item_id=15,
+                symptom_summary="描述完整",
+                dialogue_evidence="已经说明",
+                evidence_refs=[],
+                score=2,
+                score_type="类型1",
+                score_reason="完整",
+                clarify_need=None,
+            ),
+        ]
+    )
+
+    clarify = LangGraphMini._clarify_from_analysis(orchestrator, state, result, [])
+
+    assert clarify is None
+
+
+def test_fallback_flow_preserves_existing_analysis(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = LangGraphMini.__new__(LangGraphMini)
+    orchestrator.deepseek = _DummyDeepSeek()
+    orchestrator.repo = _DummyRepo()
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_make_response(
+        self,
+        sid: str,
+        state: SessionState,
+        text: str,
+        *,
+        turn_type: str = "ask",
+        extra: Optional[Dict[str, Any]] = None,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        payload = {
+            "next_utterance": text,
+            "analysis": state.analysis,
+            "turn_type": turn_type,
+        }
+        if extra:
+            payload.update(extra)
+        captured.update(payload)
+        return payload
+
+    monkeypatch.setattr(LangGraphMini, "_make_response", _fake_make_response)
+
+    state = SessionState(sid="sid", index=1)
+    state.analysis = {"items": ["previous"]}
+
+    monkeypatch.setattr(LangGraphMini, "_run_deepseek_analysis", lambda self, dialogue: None)
+    monkeypatch.setattr(
+        LangGraphMini,
+        "_score_current_item",
+        lambda self, state, transcripts, dialogue: None,
+    )
+
+    orchestrator._fallback_flow(
+        sid="sid",
+        state=state,
+        item_id=1,
+        scoring_segments=[],
+        dialogue=[],
+        transcripts=[],
+        user_text="描述",
+    )
+
+    assert state.analysis == {"items": ["previous"]}
+    assert captured["analysis"] == {"items": ["previous"]}

--- a/tests/test_orchestrator_report.py
+++ b/tests/test_orchestrator_report.py
@@ -1,0 +1,165 @@
+import sys
+import types
+from typing import Any, Dict
+
+import pytest
+
+_jinja2 = types.ModuleType("jinja2")
+
+
+class _FakeTemplate:
+    def render(self, **_: Any) -> str:
+        return ""
+
+
+class _FakeEnv:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def from_string(self, _template: str) -> _FakeTemplate:
+        return _FakeTemplate()
+
+
+_jinja2.Environment = lambda *args, **kwargs: _FakeEnv(*args, **kwargs)
+_jinja2.select_autoescape = lambda *args, **kwargs: None
+sys.modules.setdefault("jinja2", _jinja2)
+
+_weasyprint = types.ModuleType("weasyprint")
+
+
+class _FakeHTML:
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def write_pdf(self, _path: str) -> None:
+        return None
+
+
+_weasyprint.HTML = lambda *args, **kwargs: _FakeHTML(*args, **kwargs)
+sys.modules.setdefault("weasyprint", _weasyprint)
+
+from services.orchestrator.langgraph_min import LangGraphMini, SessionState
+
+
+@pytest.fixture(autouse=True)
+def _stub_pick_primary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("services.orchestrator.langgraph_min.pick_primary", lambda item_id: "下一题？")
+
+
+def _make_state() -> SessionState:
+    state = SessionState(sid="sid")
+    state.index = 5
+    state.total = 17
+    state.scores_acc = [
+        {
+            "item_id": "H05",
+            "score": 2,
+            "symptom_summary": "测试",
+            "dialogue_evidence": "引用",
+            "evidence_refs": ["u1"],
+            "score_type": "类型1",
+            "score_reason": "原因",
+        }
+    ]
+    state.analysis = {
+        "items": [],
+        "total_score": {
+            "得分序列": "1,0",
+            "pre_correction_total": 1,
+            "corrected_total": 1,
+            "correction_basis": "",
+        },
+    }
+    state.opinion = "当前情绪评分较低，如有需要仍可与专业人士交流。"
+    return state
+
+
+def test_report_request_generates_pdf(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = LangGraphMini.__new__(LangGraphMini)
+    orchestrator._persist_state = lambda state: None  # type: ignore[assignment]
+
+    captured: Dict[str, Any] = {}
+
+    def fake_prepare(self: LangGraphMini, sid: str, state: SessionState) -> Dict[str, Any]:
+        captured["prepared"] = True
+        return {
+            "items": [
+                {
+                    "item_id": "H05",
+                    "score": 2,
+                }
+            ]
+        }
+
+    def fake_build_pdf(sid: str, payload: Dict[str, Any]) -> Dict[str, str]:
+        captured["payload"] = payload
+        return {"report_url": "file:///tmp/report_sid.pdf"}
+
+    def fake_make_response(
+        self: LangGraphMini,
+        sid: str,
+        state: SessionState,
+        text: str,
+        *,
+        turn_type: str,
+        extra: Dict[str, Any] | None = None,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        response = {"next_utterance": text, "turn_type": turn_type}
+        if extra:
+            response.update(extra)
+        return response
+
+    monkeypatch.setattr(LangGraphMini, "_prepare_report_scores", fake_prepare, raising=False)
+    monkeypatch.setattr("services.orchestrator.langgraph_min.build_pdf", fake_build_pdf)
+    monkeypatch.setattr(LangGraphMini, "_make_response", fake_make_response, raising=False)
+
+    state = _make_state()
+
+    result = orchestrator._maybe_handle_report_request("sid", state, "我想获取报告")
+
+    assert result is not None
+    assert result["report_generated"] is True
+    assert result["report_url"] == "file:///tmp/report_sid.pdf"
+    assert "报告" in result["next_utterance"]
+    assert captured["payload"]["items"][0]["score"] == 2
+
+
+def test_report_request_without_scores(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = LangGraphMini.__new__(LangGraphMini)
+    orchestrator._persist_state = lambda state: None  # type: ignore[assignment]
+
+    def fake_prepare(self: LangGraphMini, sid: str, state: SessionState) -> None:
+        return None
+
+    def fake_make_response(
+        self: LangGraphMini,
+        sid: str,
+        state: SessionState,
+        text: str,
+        *,
+        turn_type: str,
+        extra: Dict[str, Any] | None = None,
+        **_: Any,
+    ) -> Dict[str, Any]:
+        response = {"next_utterance": text, "turn_type": turn_type}
+        if extra:
+            response.update(extra)
+        return response
+
+    monkeypatch.setattr(LangGraphMini, "_prepare_report_scores", fake_prepare, raising=False)
+    monkeypatch.setattr(LangGraphMini, "_make_response", fake_make_response, raising=False)
+
+    state = _make_state()
+
+    result = orchestrator._maybe_handle_report_request("sid", state, "我想生成报告")
+
+    assert result is not None
+    assert result.get("report_generated") is False
+    assert "继续评估" in result["next_utterance"]
+
+
+def test_non_report_text_returns_none() -> None:
+    orchestrator = LangGraphMini.__new__(LangGraphMini)
+    state = _make_state()
+    assert orchestrator._maybe_handle_report_request("sid", state, "好的") is None

--- a/tests/test_tts_adapter.py
+++ b/tests/test_tts_adapter.py
@@ -1,0 +1,86 @@
+import io
+import wave
+from pathlib import Path
+
+from services.tts.tts_adapter import TTSAdapter
+
+
+def _make_wav_bytes(duration_seconds: float = 0.1) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(16000)
+        frames = int(16000 * duration_seconds)
+        wav_file.writeframes(b"\x01\x00" * frames)
+    return buffer.getvalue()
+
+
+def test_tts_adapter_uses_stub_when_dashscope_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr("services.tts.tts_adapter._SPEECH_SYNTHESIZER_CLS", None)
+    adapter = TTSAdapter(out_dir=str(tmp_path))
+
+    url = adapter.synthesize("sid123", "你好")
+    assert url.startswith("file://")
+
+    audio_path = Path(url[len("file://") :])
+    assert audio_path.exists()
+
+    with wave.open(str(audio_path), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getframerate() == 16000
+
+
+def test_tts_adapter_invokes_injected_factory_and_reuses_synth(tmp_path):
+    calls = []
+    creations = []
+    instances = []
+
+    def factory(model: str, voice: str, audio_format: str):
+        creations.append((model, voice, audio_format))
+
+        class _FakeSynth:
+            def __init__(self) -> None:
+                self.call_count = 0
+
+            def call(self, text: str, **kwargs):
+                self.call_count += 1
+                calls.append({
+                    "model": model,
+                    "voice": voice,
+                    "audio_format": audio_format,
+                    "text": text,
+                    "kwargs": kwargs,
+                    "call_count": self.call_count,
+                })
+                return _make_wav_bytes()
+
+            def get_last_request_id(self):
+                return "req-123"
+
+            def get_first_package_delay(self):
+                return 42.0
+
+        synth = _FakeSynth()
+        instances.append(synth)
+        return synth
+
+    adapter = TTSAdapter(out_dir=str(tmp_path), synthesizer_factory=factory)
+
+    url1 = adapter.synthesize("sid456", "测试合成", voice="custom_voice")
+    url2 = adapter.synthesize("sid456", "再次合成", voice="custom_voice")
+
+    for url in (url1, url2):
+        assert url.startswith("file://")
+        audio_path = Path(url[len("file://") :])
+        assert audio_path.exists()
+        with wave.open(str(audio_path), "rb") as wav_file:
+            assert wav_file.getnchannels() == 1
+            assert wav_file.getnframes() > 0
+
+    assert creations == [("cosyvoice-v2", "custom_voice", "wav")]
+    assert len(instances) == 1
+    assert calls and len(calls) == 2
+    assert calls[0]["voice"] == "custom_voice"
+    assert calls[0]["kwargs"].get("format") == "wav"
+    assert calls[1]["call_count"] == 2


### PR DESCRIPTION
## Summary
- cache DashScope speech synthesizer instances per model and voice so repeated prompts reuse existing connections and purge the cache on errors
- update the injected-factory test to assert cached reuse behaviour while keeping the stub fallback intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e34bb0383883249c86d004811e620c