### PR TITLE
Add DM report endpoint with OSS upload handling

### DIFF
--- a/apps/api/router_dm.py
+++ b/apps/api/router_dm.py
@@ -2,25 +2,24 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Literal
 from uuid import uuid4
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
-from pydantic import BaseModel
-from typing import Any, Dict, List, Optional
-from uuid import uuid4
-
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field
 
 from packages.common.config import settings
 from services.orchestrator.langgraph_min import orchestrator
+from services.oss.uploader import OSSUploader
 from services.report.build import build_pdf
 from services.tts.tts_adapter import TTSAdapter
 from services.store.repository import repository
+
+LOGGER = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -72,6 +71,46 @@ async def dm_step(payload: DMStepPayload) -> StepResponse:
         scale=payload.scale or "HAMD17",
     )
     return StepResponse(**result)
+
+
+@router.post("/dm/report")
+async def generate_report(request: Request) -> Dict[str, Any]:
+    try:
+        data = await request.json()
+    except Exception:
+        return {"error": "请求体格式错误"}
+
+    sid = data.get("sid") if isinstance(data, dict) else None
+    if not sid:
+        return {"error": "缺少 sid 参数"}
+
+    try:
+        state = orchestrator._load_state(sid)
+        score_payload = orchestrator._prepare_report_scores(sid, state)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return {"error": str(exc)}
+
+    if not score_payload:
+        return {"error": "无有效评分数据，无法生成报告"}
+
+    try:
+        report_result = build_pdf(sid, score_payload)
+        local_path: Optional[str] = None
+        if isinstance(report_result, dict):
+            path_value = report_result.get("path") or report_result.get("file_path")
+            if path_value:
+                local_path = str(path_value)
+        if not local_path:
+            return {"error": "报告文件生成失败"}
+
+        uploader = OSSUploader()
+        oss_key = uploader.upload_file(local_path, oss_key_prefix="reports/")
+        report_url = uploader.get_presigned_url(oss_key)
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    LOGGER.info("报告生成成功")
+    return {"report_url": report_url, "sid": sid}
 
 
 class AsrTranscribeRequest(BaseModel):

--- a/services/report/build.py
+++ b/services/report/build.py
@@ -373,4 +373,9 @@ def build_pdf(sid: str, score_json: Dict[str, Any]) -> Dict[str, str]:
         output_path,
         metadata={"type": "report", "format": "pdf"},
     )
-    return {"report_url": oss_url or output_path.resolve().as_uri()}
+    resolved_path = output_path.resolve()
+    return {
+        "report_url": oss_url or resolved_path.as_uri(),
+        "file_path": str(resolved_path),
+        "path": str(resolved_path),
+    }


### PR DESCRIPTION
## Summary
- add a /dm/report endpoint that builds the PDF report from orchestrator state and uploads it to OSS
- expose the generated report file path from build_pdf so downstream callers can re-upload and share the file

## Testing
- pytest tests/test_report_build_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68e539f32f1c83248f8b8a0bb613cbc4