### PR TITLE
Add fixed Gradio Tingwu streaming demo

### DIFF
--- a/app_gradio_stream_test.py
+++ b/app_gradio_stream_test.py
@@ -1,0 +1,221 @@
+"""Gradio 页面：16 kHz 录音 → 听悟 WebSocket 推流 → 实时字幕."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import math
+import uuid
+from dataclasses import dataclass
+from typing import AsyncGenerator, Optional
+
+import gradio as gr
+import numpy as np
+import websockets
+
+from packages.common.config import settings
+from services.audio.tingwu_client import create_realtime_task, stop_realtime_task
+
+
+@dataclass(slots=True)
+class TingwuStreamConfig:
+    """Normalized Tingwu realtime streaming configuration."""
+
+    appkey: str
+    format: str
+    language: str
+    sample_rate: int
+    frame_ms: int = 40
+
+    @property
+    def frame_bytes(self) -> int:
+        """Number of bytes per PCM frame according to configured frame size."""
+
+        samples_per_frame = max(int(self.sample_rate * self.frame_ms / 1000), 1)
+        return samples_per_frame * 2  # 16-bit mono PCM
+
+
+def _build_config() -> TingwuStreamConfig:
+    appkey = settings.TINGWU_APPKEY or settings.ALIBABA_TINGWU_APPKEY
+    if not appkey:
+        raise RuntimeError("请在 .env 中配置 TINGWU_APPKEY 或 ALIBABA_TINGWU_APPKEY")
+
+    return TingwuStreamConfig(
+        appkey=appkey,
+        format=settings.TINGWU_FORMAT or "pcm",
+        language=settings.TINGWU_LANG or "cn",
+        sample_rate=settings.TINGWU_SAMPLE_RATE or 16000,
+    )
+
+
+def _ensure_mono(audio_data: np.ndarray) -> np.ndarray:
+    if audio_data.ndim == 1:
+        return audio_data
+    return np.mean(audio_data, axis=1)
+
+
+def _resample_if_needed(audio_data: np.ndarray, original_sr: int, target_sr: int) -> np.ndarray:
+    if original_sr == target_sr:
+        return audio_data
+    duration = audio_data.shape[0] / float(original_sr)
+    target_samples = max(int(math.ceil(duration * target_sr)), 1)
+    source_times = np.linspace(0.0, duration, num=audio_data.shape[0], endpoint=False)
+    target_times = np.linspace(0.0, duration, num=target_samples, endpoint=False)
+    return np.interp(target_times, source_times, audio_data).astype(np.float32)
+
+
+def _pcm_bytes(audio_data: np.ndarray) -> bytes:
+    normalized = np.clip(audio_data, -1.0, 1.0)
+    return (normalized * 32767).astype("<i2").tobytes()
+
+
+def _extract_text(payload: dict) -> Optional[str]:
+    for key in ("display_text", "text", "result"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+async def stream_audio_to_tingwu(
+    audio_data: np.ndarray, sample_rate: int, queue: asyncio.Queue[str]
+) -> None:
+    """推送音频到 Tingwu 并实时接收识别结果."""
+
+    cfg = _build_config()
+    mono_audio = _ensure_mono(audio_data.astype(np.float32))
+    processed_audio = _resample_if_needed(mono_audio, sample_rate, cfg.sample_rate)
+    pcm_bytes = _pcm_bytes(processed_audio)
+
+    try:
+        ws_url, task_id = await asyncio.to_thread(create_realtime_task)
+    except Exception as exc:  # pylint: disable=broad-except
+        await queue.put(f"❌ 创建听悟实时任务失败: {exc}")
+        return
+
+    start_message = {
+        "header": {
+            "namespace": "SpeechTranscription",
+            "name": "StartTranscription",
+            "appkey": cfg.appkey,
+            "message_id": str(uuid.uuid4()),
+            "task_id": task_id,
+        },
+        "payload": {
+            "format": cfg.format,
+            "sample_rate": cfg.sample_rate,
+            "language": cfg.language,
+            "enable_intermediate_result": True,
+            "enable_punctuation_prediction": True,
+            "enable_inverse_text_normalization": True,
+            "enable_semantic_sentence_detection": True,
+        },
+    }
+    stop_message = {
+        "header": {
+            "namespace": "SpeechTranscription",
+            "name": "StopTranscription",
+            "appkey": cfg.appkey,
+            "message_id": str(uuid.uuid4()),
+            "task_id": task_id,
+        }
+    }
+
+    async def receive_results(ws):  # type: ignore[no-untyped-def]
+        try:
+            async for raw in ws:
+                if isinstance(raw, bytes):
+                    continue
+                try:
+                    message = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                header = message.get("header", {})
+                payload = message.get("payload", {})
+                status = header.get("status")
+                if isinstance(status, int) and status >= 40000000:
+                    detail = payload.get("message") or payload.get("error_message")
+                    await queue.put(
+                        f"⚠️ 听悟返回错误({status}): {detail or json.dumps(payload, ensure_ascii=False)}"
+                    )
+                    continue
+                text = _extract_text(payload)
+                if not text:
+                    continue
+                name = (header.get("name") or "").lower()
+                prefix = "实时识别"
+                if "sentenceend" in name or "completed" in name or "result" in name:
+                    prefix = "最终结果"
+                await queue.put(f"{prefix}: {text}")
+        except Exception as exc:  # pylint: disable=broad-except
+            await queue.put(f"⚠️ WebSocket 监听中断: {exc}")
+
+    try:
+        async with websockets.connect(ws_url, ping_interval=10) as ws:
+            await queue.put(f"✅ 已连接听悟实时任务（TaskId: {task_id}）")
+            await ws.send(json.dumps(start_message, ensure_ascii=False))
+
+            receiver = asyncio.create_task(receive_results(ws))
+            frame_bytes = max(cfg.frame_bytes, 640)
+            for idx in range(0, len(pcm_bytes), frame_bytes):
+                await ws.send(pcm_bytes[idx : idx + frame_bytes])
+                await asyncio.sleep(cfg.frame_ms / 1000.0)
+
+            await ws.send(json.dumps(stop_message, ensure_ascii=False))
+            await queue.put("🛑 音频推流完成，等待识别收尾...")
+            await receiver
+    except Exception as exc:  # pylint: disable=broad-except
+        await queue.put(f"❌ 推流失败: {exc}")
+    finally:
+        await asyncio.to_thread(stop_realtime_task, task_id)
+
+
+def start_realtime_stream(audio: Optional[tuple[int, np.ndarray]]) -> AsyncGenerator[str, None]:
+    """录音回调，实时显示识别结果."""
+
+    if audio is None:
+
+        async def no_audio() -> AsyncGenerator[str, None]:
+            yield "未检测到音频输入"
+
+        return no_audio()
+
+    sample_rate, data = audio
+    queue: "asyncio.Queue[str]" = asyncio.Queue()
+
+    async def run_stream() -> None:
+        await stream_audio_to_tingwu(data, sample_rate, queue)
+        await queue.put("✅ 流程结束")
+
+    async def update_output() -> AsyncGenerator[str, None]:
+        task = asyncio.create_task(run_stream())
+        try:
+            while True:
+                text = await queue.get()
+                yield text
+                if any(keyword in text for keyword in ("流程结束", "失败", "中断")):
+                    break
+        finally:
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+    return update_output()
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("## 🎧 听悟实时语音识别 (16 kHz 单声道, 实时字幕)")
+    mic = gr.Audio(
+        sources=["microphone"],
+        type="numpy",
+        streaming=True,
+        label="🎙️ 麦克风输入 (16 kHz 单声道)",
+    )
+    output = gr.Textbox(label="实时识别结果", lines=6)
+    mic.stream(fn=start_realtime_stream, inputs=mic, outputs=output)
+
+
+if __name__ == "__main__":
+    demo.launch(server_name="0.0.0.0", server_port=8001)

--- a/app_gradio_stream_tingwu_fixed.py
+++ b/app_gradio_stream_tingwu_fixed.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+"""Gradio → Tingwu realtime streaming demo with continuous captions.
+
+This module mounts a Gradio interface that records microphone audio,
+resamples it to 16 kHz mono, and streams PCM frames to the Tingwu
+realtime WebSocket interface while yielding every status / transcript
+message back to the UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from collections.abc import Awaitable
+from contextlib import suppress
+from typing import AsyncGenerator, Optional, Sequence
+
+import gradio as gr
+import numpy as np
+import websockets
+from services.audio.tingwu_client import create_realtime_task, stop_realtime_task
+
+
+TARGET_SAMPLE_RATE = 16_000
+FRAME_INTERVAL_SECONDS = 0.04  # 40 ms per requirement
+SAMPLES_PER_FRAME = int(TARGET_SAMPLE_RATE * FRAME_INTERVAL_SECONDS)
+PCM_BYTES_PER_SAMPLE = 2  # int16
+FRAME_BYTE_LENGTH = SAMPLES_PER_FRAME * PCM_BYTES_PER_SAMPLE
+
+
+try:  # pragma: no cover - compatibility shim when running on Python 3.10
+    from asyncio import TaskGroup
+except ImportError:  # Python < 3.11 fallback
+
+    class TaskGroup:  # type: ignore[override]
+        """Minimal TaskGroup shim for Python 3.10 environments."""
+
+        def __init__(self) -> None:
+            self._tasks: list[asyncio.Task[object]] = []
+
+        async def __aenter__(self) -> "TaskGroup":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:
+            try:
+                if exc is not None:
+                    for task in self._tasks:
+                        task.cancel()
+                await asyncio.gather(*self._tasks, return_exceptions=True)
+            finally:
+                self._tasks.clear()
+            return None
+
+        def create_task(self, coro: Awaitable[object]) -> asyncio.Task:
+            task = asyncio.create_task(coro)
+            self._tasks.append(task)
+            return task
+
+
+def _ensure_mono(audio: np.ndarray) -> np.ndarray:
+    if audio.ndim == 1:
+        return audio
+    return np.mean(audio, axis=1)
+
+
+def _resample_to_target(audio: np.ndarray, source_rate: int) -> np.ndarray:
+    if source_rate == TARGET_SAMPLE_RATE:
+        return audio
+    if source_rate <= 0 or audio.size == 0:
+        return np.asarray([], dtype=np.float32)
+
+    duration = audio.shape[0] / float(source_rate)
+    new_length = int(math.floor(duration * TARGET_SAMPLE_RATE))
+    if new_length <= 0:
+        return np.asarray([], dtype=np.float32)
+
+    time_old = np.linspace(0.0, duration, num=audio.shape[0], endpoint=False)
+    time_new = np.linspace(0.0, duration, num=new_length, endpoint=False)
+    resampled = np.interp(time_new, time_old, audio)
+    return resampled.astype(np.float32)
+
+
+def _to_pcm_frames(audio: np.ndarray) -> bytes:
+    if audio.size == 0:
+        return b""
+    clipped = np.clip(audio, -1.0, 1.0)
+    pcm = (clipped * np.iinfo(np.int16).max).astype("<i2")
+    return pcm.tobytes()
+
+
+def _iter_pcm_frames(pcm_bytes: bytes) -> Sequence[bytes]:
+    if not pcm_bytes:
+        return []
+    frames: list[bytes] = []
+    for offset in range(0, len(pcm_bytes), FRAME_BYTE_LENGTH):
+        frame = pcm_bytes[offset : offset + FRAME_BYTE_LENGTH]
+        if len(frame) < FRAME_BYTE_LENGTH:
+            frame = frame + b"\x00" * (FRAME_BYTE_LENGTH - len(frame))
+        frames.append(frame)
+    return frames
+
+
+async def stream_audio_to_tingwu(
+    audio: np.ndarray,
+    source_rate: int,
+    queue: "asyncio.Queue[str]",
+) -> None:
+    if audio is None or audio.size == 0:
+        await queue.put("未检测到有效音频帧")
+        return
+
+    mono_audio = _ensure_mono(audio.astype(np.float32))
+    resampled = _resample_to_target(mono_audio, source_rate)
+    if resampled.size == 0:
+        await queue.put("未检测到有效音频帧")
+        return
+
+    pcm_bytes = _to_pcm_frames(resampled)
+    frames = _iter_pcm_frames(pcm_bytes)
+    await queue.put(
+        f"🎚️ 音频处理完成：{len(resampled)} 帧样本，共 {len(frames)} 个分片"
+    )
+
+    loop = asyncio.get_running_loop()
+    try:
+        ws_url, task_id = await loop.run_in_executor(None, create_realtime_task)
+    except Exception as exc:  # pragma: no cover - network failure path
+        await queue.put(f"❌ 创建实时任务失败：{exc}")
+        return
+
+    await queue.put("🔌 Tingwu 任务已创建，准备建立 WebSocket 连接…")
+
+    async def _close_task() -> None:
+        with suppress(Exception):
+            await loop.run_in_executor(None, stop_realtime_task, task_id)
+
+    try:
+        async with websockets.connect(
+            ws_url,
+            ping_interval=20,
+            ping_timeout=20,
+            close_timeout=5,
+        ) as ws:
+            await queue.put("✅ WebSocket 已连接，开始实时推流…")
+
+            async def send_loop() -> None:
+                try:
+                    for idx, frame in enumerate(frames, start=1):
+                        await ws.send(frame)
+                        await queue.put(
+                            f"📤 发送第 {idx} 帧（{len(frame)} 字节）"
+                        )
+                        await asyncio.sleep(FRAME_INTERVAL_SECONDS)
+                    await queue.put("🛑 音频帧发送完毕，发送结束指令…")
+                    await ws.send(json.dumps({"action": "Stop"}))
+                except Exception as exc:  # pragma: no cover - runtime failure
+                    await queue.put(f"❌ 发送音频时出现异常：{exc}")
+                    raise
+
+            async def recv_loop() -> None:
+                try:
+                    async for raw_msg in ws:
+                        await queue.put(f"📥 收到原始消息: {raw_msg}")
+                        with suppress(json.JSONDecodeError, TypeError):
+                            payload = json.loads(raw_msg)
+                            text = (
+                                payload.get("text")
+                                or payload.get("result")
+                                or payload.get("payload", {}).get("text")
+                                or payload.get("payload", {}).get("result")
+                            )
+                            if text:
+                                await queue.put(f"📝 实时识别：{text}")
+                except websockets.ConnectionClosedOK:
+                    await queue.put("🔚 WebSocket 正常关闭。")
+                except Exception as exc:  # pragma: no cover - runtime failure
+                    await queue.put(f"⚠️ 接收识别结果时异常：{exc}")
+                    raise
+
+            async with TaskGroup() as tg:
+                tg.create_task(send_loop())
+                tg.create_task(recv_loop())
+
+    except Exception as exc:  # pragma: no cover - connection failures
+        await queue.put(f"❌ WebSocket 连接失败：{exc}")
+    finally:
+        await _close_task()
+        await queue.put("✅ Tingwu 任务已结束。")
+
+
+async def _gradio_stream(audio) -> AsyncGenerator[str, None]:
+    if audio is None:
+        yield "未检测到有效音频帧"
+        return
+
+    if isinstance(audio, tuple):
+        sample_rate, data = audio
+    elif isinstance(audio, dict):
+        sample_rate = audio.get("sample_rate", TARGET_SAMPLE_RATE)
+        data = audio.get("data")
+    else:
+        sample_rate, data = TARGET_SAMPLE_RATE, audio
+
+    if data is None:
+        yield "未检测到有效音频帧"
+        return
+
+    np_data = np.asarray(data, dtype=np.float32)
+    queue: "asyncio.Queue[str]" = asyncio.Queue()
+
+    async def runner() -> None:
+        await stream_audio_to_tingwu(np_data, int(sample_rate), queue)
+        await queue.put("流程结束")
+
+    worker = asyncio.create_task(runner())
+    try:
+        while True:
+            message = await queue.get()
+            yield message
+            if message.endswith("流程结束"):
+                break
+    finally:
+        if not worker.done():
+            worker.cancel()
+            with suppress(asyncio.CancelledError):
+                await worker
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("## 🎧 听悟实时语音识别（16 kHz 单声道）")
+    audio_in = gr.Audio(
+        sources=["microphone"],
+        type="numpy",
+        streaming=True,
+        format="wav",
+        label="🎙️ 麦克风输入",
+    )
+    transcript = gr.Textbox(label="实时识别输出", lines=12)
+    audio_in.stream(fn=_gradio_stream, inputs=audio_in, outputs=transcript)
+
+
+async def _launch() -> None:
+    await asyncio.get_running_loop().run_in_executor(
+        None,
+        lambda: demo.queue().launch(server_name="0.0.0.0", server_port=8001),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(_launch())

--- a/services/audio/tingwu_client.py
+++ b/services/audio/tingwu_client.py
@@ -81,6 +81,18 @@ def _stop_task(task_id: str):
     return json.loads(client.do_action_with_exception(req))
 
 
+def create_realtime_task():
+    """Create a Tingwu realtime task and return its WS join URL + task id."""
+
+    return _create_task()
+
+
+def stop_realtime_task(task_id: str):
+    """Stop a Tingwu realtime task given its id."""
+
+    _stop_task(task_id)
+
+
 class TingwuRealtimeClient:
     def __init__(self, audio_file: str):
         self.audio_file = audio_file


### PR DESCRIPTION
## Summary
- add a dedicated Gradio app that streams 16 kHz mono microphone audio to Tingwu over WebSocket using 40 ms PCM frames
- coordinate concurrent send and receive loops with asyncio.TaskGroup and surface every status/result message back to the UI
- gracefully handle task lifecycle, resampling, and shutdown while yielding output through an async generator

## Testing
- python -m compileall app_gradio_stream_tingwu_fixed.py

------
https://chatgpt.com/codex/tasks/task_e_68e59c75bf80832481ad5f434df8a97b