### PR TITLE
feat: add realtime streaming mode to gradio ui

### DIFF
--- a/apps/ui-gradio/app.py
+++ b/apps/ui-gradio/app.py
@@ -1,17 +1,37 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
 
 import gradio as gr
+import numpy as np
 import requests
+import websockets
+
+from services.audio.tingwu_async_client import (
+    create_realtime_task,
+    stop_realtime_task,
+)
 
 API_BASE = (
     os.getenv("DM_API_BASE", os.getenv("API_BASE_URL", "http://localhost:8080"))
     or "http://localhost:8080"
 ).rstrip("/")
+
+
+TARGET_SAMPLE_RATE = 16_000
+FRAME_DURATION_SECONDS = 0.02  # 20 ms per frame
+PCM_BYTES_PER_SAMPLE = 2  # int16 mono
+FRAME_BYTE_LENGTH = int(TARGET_SAMPLE_RATE * FRAME_DURATION_SECONDS) * PCM_BYTES_PER_SAMPLE
+CREATE_TASK_MAX_RETRIES = 3
+CONNECT_MAX_RETRIES = 3
+CONNECT_BACKOFF_SECONDS = 1.5
+PING_INTERVAL_SECONDS = 15
 
 
 def _init_session() -> str:
@@ -130,6 +150,238 @@ def user_step(
     return history, risk_text, progress, session_id, audio_value
 
 
+def _ensure_mono(audio: np.ndarray) -> np.ndarray:
+    if audio.ndim == 1:
+        return audio
+    return np.mean(audio, axis=1)
+
+
+def _resample_audio(audio: np.ndarray, source_rate: int) -> np.ndarray:
+    if source_rate == TARGET_SAMPLE_RATE:
+        return audio
+    if source_rate <= 0 or audio.size == 0:
+        return np.asarray([], dtype=np.float32)
+
+    duration = audio.shape[0] / float(source_rate)
+    target_length = max(int(round(duration * TARGET_SAMPLE_RATE)), 1)
+    source_positions = np.linspace(0.0, duration, num=audio.shape[0], endpoint=False)
+    target_positions = np.linspace(0.0, duration, num=target_length, endpoint=False)
+    resampled = np.interp(target_positions, source_positions, audio)
+    return resampled.astype(np.float32)
+
+
+def _to_pcm(audio: np.ndarray) -> bytes:
+    if audio.size == 0:
+        return b""
+    clipped = np.clip(audio, -1.0, 1.0)
+    pcm = (clipped * np.iinfo(np.int16).max).astype("<i2")
+    return pcm.tobytes()
+
+
+def _iter_frames(pcm_bytes: bytes) -> List[bytes]:
+    if not pcm_bytes:
+        return []
+    frames: List[bytes] = []
+    for offset in range(0, len(pcm_bytes), FRAME_BYTE_LENGTH):
+        frame = pcm_bytes[offset : offset + FRAME_BYTE_LENGTH]
+        if len(frame) < FRAME_BYTE_LENGTH:
+            frame = frame + b"\x00" * (FRAME_BYTE_LENGTH - len(frame))
+        frames.append(frame)
+    return frames
+
+
+def _extract_text(payload: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    result = payload.get("result")
+    if isinstance(result, str) and result.strip():
+        return result.strip()
+    if isinstance(result, dict):
+        text = result.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    if isinstance(payload.get("text"), str) and payload["text"].strip():
+        return payload["text"].strip()
+    return None
+
+
+async def _stream_realtime_audio(
+    sample_rate: int,
+    audio_data: np.ndarray,
+    queue: "asyncio.Queue[object]",
+) -> None:
+    audio_data = audio_data.astype(np.float32)
+    mono_audio = _ensure_mono(audio_data)
+    resampled = _resample_audio(mono_audio, sample_rate)
+    if resampled.size == 0:
+        await queue.put("⚠️ 未检测到有效的音频样本。")
+        return
+
+    pcm_bytes = _to_pcm(resampled)
+    frames = _iter_frames(pcm_bytes)
+    await queue.put(
+        "🎙️ 音频处理完成，准备推流："
+        f"{len(resampled)} 个样本，拆分为 {len(frames)} 帧。"
+    )
+
+    task_id: Optional[str] = None
+    ws_url: Optional[str] = None
+    for attempt in range(1, CREATE_TASK_MAX_RETRIES + 1):
+        try:
+            ws_url, task_id = await create_realtime_task()
+            await queue.put(f"✅ 已创建实时任务，第 {attempt} 次尝试成功。")
+            break
+        except Exception as exc:  # pragma: no cover - network failure path
+            await queue.put(
+                f"❌ 创建实时任务失败（第 {attempt} 次）：{exc}"
+            )
+            if attempt == CREATE_TASK_MAX_RETRIES:
+                return
+            await asyncio.sleep(attempt * 0.5)
+
+    if not ws_url or not task_id:
+        await queue.put("❌ 未能获得有效的 WebSocket 地址或任务 ID。")
+        return
+
+    async def _cleanup_task() -> None:
+        if not task_id:
+            return
+        with contextlib.suppress(Exception):
+            await stop_realtime_task(task_id)
+
+    try:
+        backoff = CONNECT_BACKOFF_SECONDS
+        for attempt in range(1, CONNECT_MAX_RETRIES + 1):
+            try:
+                await queue.put(
+                    f"🔌 正在连接 WebSocket（尝试 {attempt}/{CONNECT_MAX_RETRIES}）…"
+                )
+                async with websockets.connect(
+                    ws_url,
+                    ping_interval=None,
+                    close_timeout=5,
+                ) as ws:
+                    await queue.put("✅ WebSocket 连接成功，开始推流。")
+
+                    async def send_loop() -> None:
+                        try:
+                            for index, frame in enumerate(frames, start=1):
+                                await ws.send(frame)
+                                if index % 10 == 0 or index == len(frames):
+                                    await queue.put(
+                                        f"📤 已发送 {index}/{len(frames)} 帧。"
+                                    )
+                                await asyncio.sleep(FRAME_DURATION_SECONDS)
+                            await queue.put("🛑 所有音频帧已发送，发送停止指令。")
+                            await ws.send(json.dumps({"action": "Stop"}))
+                        except Exception as exc:  # pragma: no cover
+                            await queue.put(f"⚠️ 发送音频数据异常：{exc}")
+                            raise
+
+                    async def recv_loop() -> None:
+                        try:
+                            async for raw_msg in ws:
+                                if isinstance(raw_msg, bytes):
+                                    continue
+                                try:
+                                    message = json.loads(raw_msg)
+                                except json.JSONDecodeError:
+                                    await queue.put(
+                                        "⚠️ 收到无法解析的消息，已忽略。"
+                                    )
+                                    continue
+                                header = message.get("header", {})
+                                payload = message.get("payload", {})
+                                name = header.get("name")
+                                if isinstance(name, str):
+                                    await queue.put(f"📥 收到事件：{name}")
+                                text = _extract_text(payload)
+                                if text:
+                                    await queue.put(f"📝 实时识别：{text}")
+                        except websockets.ConnectionClosedOK:
+                            await queue.put("🔚 WebSocket 正常关闭。")
+                        except Exception as exc:  # pragma: no cover
+                            await queue.put(f"⚠️ 接收识别结果异常：{exc}")
+                            raise
+
+                    async def heartbeat_loop() -> None:
+                        try:
+                            while True:
+                                await asyncio.sleep(PING_INTERVAL_SECONDS)
+                                await ws.ping()
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            return
+
+                    send_task = asyncio.create_task(send_loop())
+                    recv_task = asyncio.create_task(recv_loop())
+                    heartbeat_task = asyncio.create_task(heartbeat_loop())
+
+                    done, pending = await asyncio.wait(
+                        {send_task, recv_task},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for task in pending:
+                        task.cancel()
+                    heartbeat_task.cancel()
+                    with contextlib.suppress(Exception):
+                        await asyncio.gather(*pending, return_exceptions=True)
+                    with contextlib.suppress(Exception):
+                        await heartbeat_task
+                    for task in done:
+                        exc = task.exception()
+                        if exc:
+                            raise exc
+                    break
+            except Exception as exc:  # pragma: no cover - connection failure
+                await queue.put(f"❌ WebSocket 连接失败：{exc}")
+                if attempt == CONNECT_MAX_RETRIES:
+                    raise
+                await asyncio.sleep(backoff)
+                backoff *= 2
+    finally:
+        with contextlib.suppress(Exception):
+            await _cleanup_task()
+        await queue.put("✅ 实时任务已结束。")
+
+
+async def realtime_stream_to_frontend(
+    audio: Optional[Tuple[int, np.ndarray]]
+) -> AsyncGenerator[str, None]:
+    if not audio:
+        yield "⚠️ 未接收到麦克风音频。"
+        return
+
+    sample_rate, data = audio
+    if data is None or getattr(data, "size", 0) == 0:
+        yield "⚠️ 音频数据为空。"
+        return
+
+    queue: "asyncio.Queue[object]" = asyncio.Queue()
+    sentinel = object()
+
+    async def runner() -> None:
+        try:
+            await _stream_realtime_audio(sample_rate, data, queue)
+        finally:
+            await queue.put(sentinel)
+
+    worker = asyncio.create_task(runner())
+    try:
+        while True:
+            message = await queue.get()
+            if message is sentinel:
+                break
+            if isinstance(message, str):
+                yield message
+    finally:
+        if not worker.done():
+            worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+
+
 def build_ui() -> gr.Blocks:
     with gr.Blocks(title="Depression Agent UI") as demo:
         session_state = gr.State(_init_session())
@@ -145,6 +397,25 @@ def build_ui() -> gr.Blocks:
                 risk_alert = gr.Markdown("无紧急风险提示。")
                 progress_display = gr.JSON(label="进度状态")
                 send_button = gr.Button("发送")
+
+            with gr.Tab("实时识别"):
+                gr.Markdown("## 🎧 实时语音识别")
+                mic = gr.Audio(
+                    sources=["microphone"],
+                    type="numpy",
+                    streaming=True,
+                    label="点击开始录音以推流至听悟",
+                )
+                realtime_output = gr.Textbox(
+                    label="实时识别输出",
+                    lines=8,
+                    interactive=False,
+                )
+                mic.stream(
+                    fn=realtime_stream_to_frontend,
+                    inputs=mic,
+                    outputs=realtime_output,
+                )
 
             with gr.Tab("报告"):
                 gr.Markdown("## 生成评估报告")


### PR DESCRIPTION
## Summary
- add a realtime microphone streaming tab to the Gradio UI and surface incremental recognition updates
- preprocess microphone audio into 16 kHz PCM frames and stream them over Tingwu WebSocket tasks with retries, heartbeat, and cleanup
- expose the async realtime generator so mic.stream can print status messages to the frontend

## Testing
- python -m compileall apps/ui-gradio/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e6815e922c83248544953aa2d85b23